### PR TITLE
Add mask_unix_sock for [censorship] masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ tls_domain = "petrovich.ru"
 mask = true
 mask_port = 443
 # mask_host = "petrovich.ru" # Defaults to tls_domain if not set
+# mask_unix_sock = "/var/run/nginx.sock" # Unix socket (mutually exclusive with mask_host)
 fake_cert_len = 2048
 
 # === Access Control & Users ===

--- a/config.toml
+++ b/config.toml
@@ -48,6 +48,7 @@ tls_domain = "google.ru"
 mask = true
 mask_port = 443
 # mask_host = "petrovich.ru" # Defaults to tls_domain if not set
+# mask_unix_sock = "/var/run/nginx.sock" # Unix socket (mutually exclusive with mask_host)
 fake_cert_len = 2048
 
 # === Access Control & Users ===

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,10 +130,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.general.modes.secure,
         config.general.modes.tls);
     info!("TLS domain: {}", config.censorship.tls_domain);
-    info!("Mask: {} -> {}:{}",
-        config.censorship.mask,
-        config.censorship.mask_host.as_deref().unwrap_or(&config.censorship.tls_domain),
-        config.censorship.mask_port);
+    if let Some(ref sock) = config.censorship.mask_unix_sock {
+        info!("Mask: {} -> unix:{}", config.censorship.mask, sock);
+        if !std::path::Path::new(sock).exists() {
+            warn!("Unix socket '{}' does not exist yet. Masking will fail until it appears.", sock);
+        }
+    } else {
+        info!("Mask: {} -> {}:{}",
+            config.censorship.mask,
+            config.censorship.mask_host.as_deref().unwrap_or(&config.censorship.tls_domain),
+            config.censorship.mask_port);
+    }
 
     if config.censorship.tls_domain == "www.google.com" {
         warn!("Using default tls_domain. Consider setting a custom domain.");


### PR DESCRIPTION
`[censorship]` now supports `mask_unix_sock` — masking backend via Unix socket instead of TCP. Needed when the web server only listens on a socket and has no TCP port exposed.

Inspired by `target` behavior in Xray-core. Ideally the same should be done for inbound traffic (`[server]`), but that's a bigger change — `ClientHandler` is tightly coupled to `TcpStream`.

`mask_unix_sock` and `mask_host` are mutually exclusive. If both are set, startup fails with an error. If neither is set, `mask_host` defaults to `tls_domain` as before — fully backward compatible.

## Example

```toml
[censorship]
tls_domain = "mydomain.com"
mask = true
mask_unix_sock = "/var/run/nginx.sock"
```

```nginx
server {
    listen unix:/var/run/nginx.sock ssl;
    http2   on;
    server_name mydomain.ru;
    
    ssl_certificate ...;
    ssl_certificate_key ...;
    
    ...
}
```

### Validation

- Empty path — error
- Path > 107 bytes — error (kernel limit)
- Non-Unix platform — error
- Socket file missing at startup — warning (backend may start later)
