### PR TITLE
Fix "Read-only file system" and "Permission denied" errors for proxy-secret cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,12 @@ services:
     restart: unless-stopped
     ports:
       - "443:443"
+    # Allow caching 'proxy-secret' in read-only container
+    working_dir: /run/telemt
     volumes:
-      - ./config.toml:/app/config.toml:ro
+      - ./config.toml:/run/telemt/config.toml:ro
+    tmpfs:
+      - /run/telemt:rw,mode=1777,size=1m
     environment:
       - RUST_LOG=info
     # Uncomment this line if you want to use host network for IPv6, but bridge is default and usually better


### PR DESCRIPTION
**The problem:**
When starting the container, the application attempts to cache the `proxy-secret` file in the working directory, resulting in the following errors:

`WARN telemt::transport::middle_proxy::secret: Failed to cache proxy-secret (non-fatal) error=Read-only file system (os error 30)`

**The solution:**
- Changed `working_dir` to `/run/telemt` to separate the application logic from the writable data area.
- Added a `tmpfs` mount at `/run/telemt` with `mode=1777`. This allows the non-root user to successfully write the `proxy-secret` cache file.
- Updated the `config.toml` mount path to match the new working directory.