### PR TITLE
Fix: public_host/public_port + unix socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "telemt"
-version = "1.2.0"
+version = "3.0.0"
 dependencies = [
  "aes",
  "base64",
@@ -1741,6 +1760,8 @@ dependencies = [
  "libc",
  "lru",
  "md-5",
+ "num-bigint",
+ "num-traits",
  "parking_lot",
  "proptest",
  "rand",

--- a/README.md
+++ b/README.md
@@ -208,10 +208,6 @@ then Ctrl+X -> Y -> Enter to save
 ## Configuration
 ### Minimal Configuration for First Start
 ```toml
-# === UI ===
-# Users to show in the startup log (tg:// links)
-show_link = ["hello"]
-
 # === General Settings ===
 [general]
 prefer_ipv6 = false
@@ -239,6 +235,12 @@ ip = "0.0.0.0"
 
 [[server.listeners]]
 ip = "::"
+
+# Users to show in the startup log (tg:// links)
+[general.links]
+show = ["hello"] # Users to show in the startup log (tg:// links)
+# public_host = "proxy.example.com"  # Host (IP or domain) for tg:// links
+# public_port = 443                  # Port for tg:// links (default: server.port)
 
 # === Timeouts (in seconds) ===
 [timeouts]
@@ -287,6 +289,10 @@ weight = 10
 # address = "127.0.0.1:9050"
 # enabled = false
 # weight = 1
+
+# === DC Address Overrides ===
+# [dc_overrides]
+# "203" = "91.105.192.100:443"
 ```
 ### Advanced
 #### Adtag

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,3 @@
-# === UI ===
-# Users to show in the startup log (tg:// links)
-show_link = ["hello"]
-
 # === General Settings ===
 [general]
 prefer_ipv6 = true
@@ -24,6 +20,8 @@ tls = true
 port = 443
 listen_addr_ipv4 = "0.0.0.0"
 listen_addr_ipv6 = "::"
+# listen_unix_sock = "/var/run/telemt.sock" # Unix socket
+# listen_unix_sock_perm = "0666" # Socket file permissions
 # metrics_port = 9090
 # metrics_whitelist = ["127.0.0.1", "::1"]
 
@@ -34,6 +32,12 @@ ip = "0.0.0.0"
 
 [[server.listeners]]
 ip = "::"
+
+# Users to show in the startup log (tg:// links)
+[general.links]
+show = ["hello"] # Users to show in the startup log (tg:// links)
+# public_host = "proxy.example.com"  # Host (IP or domain) for tg:// links
+# public_port = 443                  # Port for tg:// links (default: server.port)
 
 # === Timeouts (in seconds) ===
 [timeouts]
@@ -65,7 +69,7 @@ hello = "00000000000000000000000000000000"
 # hello = 50
 
 # [access.user_max_unique_ips]
-# hello = 5  
+# hello = 5
 
 # [access.user_data_quota]
 # hello = 1073741824 # 1 GB
@@ -81,3 +85,7 @@ weight = 10
 # address = "127.0.0.1:1080"
 # enabled = false
 # weight = 1
+
+# === DC Address Overrides ===
+# [dc_overrides]
+# "203" = "91.105.192.100:443"


### PR DESCRIPTION
# Fix: public_host/public_port + unix socket

Restore functionality broken in recent main merge:

- `[general.links]` — new config section with `public_host` and `public_port` to override IP/port in tg:// links
- Unix socket-only mode — setup was placed after `listeners.is_empty() → exit` check, making socket-only configs impossible
- `listen_unix_sock_perm` — chmod socket after bind (octal string, e.g. `"0666"`)
- `show_link` migrated to `[general.links] show` with backward compatibility
