### PR TITLE
docs: update README with new 'announce' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ listen_addr_ipv6 = "::"
 # Listen on multiple interfaces/IPs (overrides listen_addr_*)
 [[server.listeners]]
 ip = "0.0.0.0"
-# announce_ip = "1.2.3.4" # Optional: Public IP for tg:// links
+# announce = "my.hostname.tld" # Optional: hostname for tg:// links
+# OR
+# announce = "1.2.3.4" # Optional: Public IP for tg:// links
 
 [[server.listeners]]
 ip = "::"


### PR DESCRIPTION
## Summary

Updates README documentation to reflect the new `announce` parameter that supports both hostnames and IP addresses.

## Changes

- Replace deprecated `announce_ip` example with new `announce` parameter
- Show both hostname and IP address usage examples

## Before
```toml
[[server.listeners]]
ip = 0.0.0.0
# announce_ip = 1.2.3.4 # Optional: Public IP for tg:// links
```

## After
```toml
[[server.listeners]]
ip = 0.0.0.0
# announce = my.hostname.tld # Optional: hostname for tg:// links
# OR
# announce = 1.2.3.4 # Optional: Public IP for tg:// links
```

Related to #100