### PR TITLE
Add GitHub Actions release workflow for multi-platform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'  # Matches tags like 3.0.0, 3.1.2, etc.
   workflow_dispatch:  # Manual trigger from GitHub Actions UI
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -13,6 +16,9 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: false
       matrix:
@@ -26,11 +32,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1 # v1
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Install cross-compilation tools
@@ -39,7 +46,7 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry
@@ -50,7 +57,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.target }}-cargo-
 
       - name: Build Release
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@ae10961054e4aa8bff448f48a500763b90d5c550 # v1.0.1
         with:
           use-cross: true
           command: build
@@ -63,7 +70,7 @@ jobs:
           sha256sum ${{ matrix.asset_name }}.tar.gz > ${{ matrix.asset_name }}.sha256
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ matrix.asset_name }}
           path: |
@@ -79,12 +86,12 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe360a41fb53f90de6ddce8c4c8a # v2.2.1
         with:
           files: artifacts/**/*
           generate_release_notes: true


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow to automatically build and publish release binaries for multiple platforms when a version tag is pushed.

## Features

- **Trigger**: Activates on semantic version tags (e.g., `3.0.0`, `3.1.2`)
- **Manual trigger**: Also supports `workflow_dispatch` for manual runs from GitHub Actions UI
- **Matrix build**: Parallel builds for:
  - `x86_64-unknown-linux-gnu`
  - `aarch64-unknown-linux-gnu`
- **Cross-compilation**: Uses `cross` for reliable ARM64 builds
- **Artifacts**: Creates `.tar.gz` archives with SHA256 checksums
- **Auto-release**: Creates GitHub Release with generated release notes
- **Pre-release detection**: Marks as pre-release if tag contains `-rc`, `-beta`, or `-alpha`

## Usage

To trigger a release:
```bash
git tag 3.0.1
git push origin 3.0.1
```

## Output Artifacts

- `telemt-x86_64-linux.tar.gz` + `.sha256`
- `telemt-aarch64-linux.tar.gz` + `.sha256`

## Testing

The workflow can be tested manually via GitHub Actions UI (Run workflow button) after merging to main.