### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -5,5 +5,5 @@ pub mod hash;
 pub mod random;
 
 pub use aes::{AesCtr, AesCbc};
-pub use hash::{sha256, sha256_hmac, sha1, md5, crc32, derive_middleproxy_keys, build_middleproxy_prekey};
+pub use hash::{sha256, sha256_hmac, crc32, derive_middleproxy_keys, build_middleproxy_prekey};
 pub use random::SecureRandom;

--- a/src/protocol/constants.rs
+++ b/src/protocol/constants.rs
@@ -1,6 +1,6 @@
 //! Protocol constants and datacenter addresses
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::LazyLock;
 
 // ============= Telegram Datacenters =============
@@ -202,7 +202,6 @@ pub static RESERVED_NONCE_CONTINUES: &[[u8; 4]] = &[
 // ============= RPC Constants (for Middle Proxy) =============
 
 /// RPC Proxy Request
-
 /// RPC Flags (from Erlang mtp_rpc.erl)
 pub const RPC_FLAG_NOT_ENCRYPTED: u32 = 0x2;
 pub const RPC_FLAG_HAS_AD_TAG: u32    = 0x8;

--- a/src/protocol/obfuscation.rs
+++ b/src/protocol/obfuscation.rs
@@ -2,7 +2,6 @@
 
 use zeroize::Zeroize;
 use crate::crypto::{sha256, AesCtr};
-use crate::error::Result;
 use super::constants::*;
 
 /// Obfuscation parameters from handshake

--- a/src/protocol/tls.rs
+++ b/src/protocol/tls.rs
@@ -5,7 +5,6 @@
 //! actually carries MTProto authentication data.
 
 use crate::crypto::{sha256_hmac, SecureRandom};
-use crate::error::{ProxyError, Result};
 use super::constants::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 use num_bigint::BigUint;


### PR DESCRIPTION
## Summary
This PR fixes clippy warnings to ensure clean builds with `cargo clippy -- -D warnings`.

## Changes
- Removed unused imports `sha1` and `md5` from `src/crypto/mod.rs`
- Removed unused import `Ipv6Addr` from `src/protocol/constants.rs`
- Fixed empty line after doc comment in `src/protocol/constants.rs`
- Removed unused import `Result` from `src/protocol/obfuscation.rs`
- Removed unused imports `ProxyError` and `Result` from `src/protocol/tls.rs`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Code compiles successfully with `cargo check`