### PR TITLE
Handle IPv6 ENETUNREACH in STUN probe gracefully

### DIFF
--- a/src/network/stun.rs
+++ b/src/network/stun.rs
@@ -50,10 +50,11 @@ pub async fn stun_probe_family(stun_addr: &str, family: IpFamily) -> Result<Opti
 
     let target_addr = resolve_stun_addr(stun_addr, family).await?;
     if let Some(addr) = target_addr {
-        socket
-            .connect(addr)
-            .await
-            .map_err(|e| ProxyError::Proxy(format!("STUN connect failed: {e}")))?;
+        match socket.connect(addr).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NetworkUnreachable => return Ok(None),
+            Err(e) => return Err(ProxyError::Proxy(format!("STUN connect failed: {e}"))),
+        }
     } else {
         return Ok(None);
     }


### PR DESCRIPTION
## Problem

When IPv6 is not available on the host, `stun_probe_family` for IPv6 fails at `socket.connect(addr)` with:

```
STUN connect failed: Network is unreachable (os error 101)
```

This error propagates through `stun_probe_dual` via `v6?`, causing the entire dual STUN probe to return `Err` — even when the IPv4 probe succeeded. As a result, a spurious `WARN` is logged on every startup on hosts without IPv6:

```
WARN telemt::network::probe: STUN probe failed, continuing without reflection error=Proxy error: STUN connect failed: Network is unreachable (os error 101)
```

## Fix

Match on the connect error in `stun_probe_family`: if the error kind is `NetworkUnreachable`, return `Ok(None)` (family not available) instead of `Err`. All other errors still propagate.

```rust
match socket.connect(addr).await {
    Ok(()) => {}
    Err(e) if e.kind() == std::io::ErrorKind::NetworkUnreachable => return Ok(None),
    Err(e) => return Err(ProxyError::Proxy(format!("STUN connect failed: {e}"))),
}
```

`ErrorKind::NetworkUnreachable` is stable since Rust 1.83.

## Result

On hosts without IPv6, `stun_probe_dual` now returns `Ok(DualStunResult { v4: Some(...), v6: None })` instead of `Err`, and no warning is logged.