### PR TITLE
fix(ci): replace deprecated actions-rs/cargo with direct cross commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-cargo-
 
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
       - name: Build Release
-        uses: actions-rs/cargo@ae10961054e4aa8bff448f48a500763b90d5c550 # v1.0.1
-        with:
-          use-cross: true
-          command: build
-          args: --release --target ${{ matrix.target }}
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Package binary
         run: |


### PR DESCRIPTION
## Problem

The `actions-rs/cargo` action (`actions-rs/cargo@ae10961054e4aa8bff448f48a500763b90d5c550`) used in the release workflow is deprecated and no longer available. The `actions-rs` organization has been archived, causing CI failures during release builds.

## Solution

Replace the deprecated action with direct `cross` commands:

1. **Install cross** - Uses `cargo install cross --git https://github.com/cross-rs/cross` to get the latest version
2. **Build Release** - Uses direct `cross build --release --target ${{ matrix.target }}` command

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (cosmetic change)

## Changes Made

```diff
-      - name: Build Release
-        uses: actions-rs/cargo@ae10961054e4aa8bff448f48a500763b90d5c550 # v1.0.1
-        with:
-          use-cross: true
-          command: build
-          args: --release --target ${{ matrix.target }}

+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build Release
+        run: cross build --release --target ${{ matrix.target }}
```

## Testing

This fix will be validated by the CI workflow itself once merged. The release build should succeed with the new cross commands.