### PR TITLE
feat: implement selective routing for "scope_*" users

### DIFF
--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -208,6 +208,8 @@ impl ProxyConfig {
                 upstream_type: UpstreamType::Direct { interface: None },
                 weight: 1,
                 enabled: true,
+                scopes: String::new(),
+                selected_scope: String::new(),
             });
         }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -403,6 +403,10 @@ pub struct UpstreamConfig {
     pub weight: u16,
     #[serde(default = "default_true")]
     pub enabled: bool,
+    #[serde(default)]
+    pub scopes: String,
+    #[serde(skip)]
+    pub selected_scope: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/proxy/direct_relay.rs
+++ b/src/proxy/direct_relay.rs
@@ -45,7 +45,7 @@ where
     );
 
     let tg_stream = upstream_manager
-        .connect(dc_addr, Some(success.dc_idx))
+        .connect(dc_addr, Some(success.dc_idx), user.strip_prefix("scope_").filter(|s| !s.is_empty()))
         .await?;
 
     debug!(peer = %success.peer, dc_addr = %dc_addr, "Connected, performing TG handshake");


### PR DESCRIPTION
- Users with "scope_{name}" prefix are routed to upstreams where {name} is present in the "scopes" property (comma-separated).
- Strict separation: Scoped upstreams are excluded from general routing, and vice versa.
- Constraint: SOCKS upstreams and DIRECT(`use_middle_proxy = false`) mode only.

Example:
  User "scope_hello" matches an upstream with `scopes = "world,hello"`

---

## Telemt - Selective Socks Upstream
В связке с [3proxy-fup](https://github.com/unuunn/3proxy-fup) это является готовым решением для запуска Telemt в режиме Fair Usage Policy (*пакет трафика на максимальной скорости, с ограничением скорости после окончания*).  


### Как работает
Патч, который позволяет привязать к конкретному пользователю определенный socks `upstream`, плюс аутентификация на прокси будет с именем пользователя в telemt.
Благодаря этому появляется возможность управлять трафиком пользователя в показателях объем/скорость/время.

*Я очень **не** люблю rust, за его синтаксис. Учитывайте, что писать на нем, больше пришлось, чем хотелось*

### Логика работы
Если у пользователя имя начинается с префикса `scope_`, он будет выделен в отдельную группу, которая для подключения будет использовать `upstreams`, у которых этот пользователь указан в свойстве `scopes`, (*без префикса `scope_`, для удобства*).  
Подключение к такому прокси-апстриму будет выполняться с именем пользователя в качестве имени и пароля для прокси.
Апстримы, имеющие/не имеющие `scopes` не пересекаются.
(*для scope пользователей только scopes апстримы, и наоборот*)

Работает это все только режиме direct (`use_middle_proxy = false
`) и только с `socks4/socks5` прокси.

#### Пример конфигурации
Эта конфигурация-пример, для режима [Fair Usage Policy в связке с 3proxy-fup](https://github.com/unuunn/3proxy-fup), тут отражены только основные изменения. Полную версию конфига берите из оригинального [README_ORIG.md](./README_ORIG.md) 
```bash
[general]
use_middle_proxy = false
# Поддерживается только direct режим

[access.users]
# format: "username" = "32_hex_chars_secret"
tguser1 = "00000000000000000000000000000000"
scope_hello = "10000000000000000000000000000000"
scope_unlim = "20000000000000000000000000000000"
scope_undef = "30000000000000000000000000000000"

# === Upstreams & Routing ===
# Стандартный апстрим для НЕ обычных users
[[upstreams]]
type = "direct"
enabled = true
weight = 1

# Стандартный апстрим для обычных users
[[upstreams]]
type = "socks5"
address = "192.168.1.1:1080"
enabled = true
weight = 10

# Апстрим только для users.scope_* -- "hwllo,world,hello,unlim"
[[upstreams]]
type = "socks5"
address = "127.0.0.1:1081"
enabled = true
weight = 10
username = "telemt"
password = "telemt"
# Тк, прокси с авторизацией, надо указать username/password,
# они переопределятся на USER:USER у scope_USER
# например: scope_hello будет ходить на прокси как hello:hello итд

scopes = "hwllo,world,hello,unlim"
# в scopes через запятую перечислены scope_* пользователи
```
В конфиге выше для прокси заведено 4 пользователя, 
и 3 апстрима:
* прямой, имеет низкий вес, будет выбран как резервный
* через прокси, для обычных пользователей
* через прокси, для `scope_*` пользователей

пользователи:
* **tguser1** :  обычный пользователь, будет использовать два апстрима без `scopes`
* **scope_hello** : определен в `scopes`, будет подключаться к upstream как `hello:hello`  
* **scope_unlim** : определен в `scopes`, будет подключаться к upstream как `unlim:unlim`  
  `scopes = "hwllo,world,hello,unlim"`
* **scope_undef** : нигде не определен, не удастся подключиться, будет сыпать в логах ошибками


### Media
Пример работы. На видео слева счетчик соединений и telemt, справа 3proxy-fup.  У пользователя лимит в 15 МБ трафика,
видно что сначала все работает хорошо, потом пользователь пытается загрузить большое видео, кончается трафик и включается медленный режим, 3proxy пишет "Quota exceeded", далее картинки грузятся уже по лимиту скорости.

https://github.com/user-attachments/assets/b9a51aac-5190-4a64-92f0-ecc63ccf18ae

### Архитектура проблемы

<img width="1501" height="1542" alt="Image" src="https://github.com/user-attachments/assets/503bc9a6-e2ea-429b-b12e-9fd8c67803f9" />

### Архитектура решения в коде

<img width="1604" height="739" alt="Image" src="https://github.com/user-attachments/assets/b54cbaa5-0783-43bf-b5b7-9aa8fb0ee653" />