### PR TITLE
ci: add musl build targets for static Linux binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,16 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             artifact_name: telemt
-            asset_name: telemt-x86_64-linux
+            asset_name: telemt-x86_64-linux-gnu
           - target: aarch64-unknown-linux-gnu
             artifact_name: telemt
-            asset_name: telemt-aarch64-linux
+            asset_name: telemt-aarch64-linux-gnu
+          - target: x86_64-unknown-linux-musl
+            artifact_name: telemt
+            asset_name: telemt-x86_64-linux-musl
+          - target: aarch64-unknown-linux-musl
+            artifact_name: telemt
+            asset_name: telemt-aarch64-linux-musl
 
     steps:
       - name: Checkout repository
@@ -60,6 +66,8 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build Release
+        env:
+          RUSTFLAGS: ${{ contains(matrix.target, 'musl') && '-C target-feature=+crt-static' || '' }}
         run: cross build --release --target ${{ matrix.target }}
 
       - name: Package binary


### PR DESCRIPTION
## Summary

This PR expands the release build matrix to include `aarch64-unknown-linux-musl` and `x86_64-unknown-linux-musl` targets, enabling the production of statically linked Linux binaries.

## Changes

### Build Matrix Expansion
- Added `x86_64-unknown-linux-musl` target (produces `telemt-x86_64-linux-musl`)
- Added `aarch64-unknown-linux-musl` target (produces `telemt-aarch64-linux-musl`)
- Renamed existing gnu targets for clarity:
  - `telemt-x86_64-linux` → `telemt-x86_64-linux-gnu`
  - `telemt-aarch64-linux` → `telemt-aarch64-linux-gnu`

### Cross-Compilation Configuration
The existing `cross` tool installation is leveraged for musl targets. The `cross` tool natively handles musl targets using Docker images with the appropriate toolchain, requiring no additional setup.

### Static Linking
Added `RUSTFLAGS` environment variable that applies `-C target-feature=+crt-static` specifically for musl targets to ensure fully static binaries. This flag is only applied when the target contains "musl", leaving gnu targets unchanged.

## Benefits

- **Portability**: Statically linked musl binaries run on any Linux distribution without glibc compatibility concerns
- **Container-friendly**: Perfect for minimal Docker images (e.g., Alpine)
- **Smaller footprint**: Single binary deployment without runtime dependencies
- **ARM64 support**: Provides static binaries for both x86_64 and aarch64 architectures

## Release Artifacts

The workflow now produces 4 binary packages:
1. `telemt-x86_64-linux-gnu.tar.gz` - Dynamically linked (x86_64)
2. `telemt-aarch64-linux-gnu.tar.gz` - Dynamically linked (ARM64)
3. `telemt-x86_64-linux-musl.tar.gz` - Statically linked (x86_64)
4. `telemt-aarch64-linux-musl.tar.gz` - Statically linked (ARM64)

Each package includes a corresponding `.sha256` checksum file.