### PR TITLE
docs: Document disable_colors configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ prefer_ipv6 = false
 fast_mode = true
 use_middle_proxy = false
 # ad_tag = "..."
+# disable_colors = false  # Disable colored output in logs (useful for files/systemd)
 
 [network]
 ipv4 = true
@@ -215,7 +216,9 @@ ip = "::"
 
 # Users to show in the startup log (tg:// links)
 [general.links]
-show = ["hello"] # Users to show in the startup log (tg:// links)
+show = ["hello"]          # Only show links for user "hello"
+# show = ["alice", "bob"] # Only show links for alice and bob
+# show = "*"              # Show links for all users
 # public_host = "proxy.example.com"  # Host (IP or domain) for tg:// links
 # public_port = 443                  # Port for tg:// links (default: server.port)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the `disable_colors` configuration parameter in the `[general]` section. The parameter was already implemented in the codebase but was not documented in the README, making it a hidden feature that users could not easily discover.

## Changes Made

### Files Modified
- **README.md**: Added documentation for the `disable_colors` parameter in the Minimal Configuration example. Also added documentation for `show = *` to show all user links.

### Specific Changes
```diff
# === General Settings ===
[general]
# prefer_ipv6 is deprecated; use [network].prefer
prefer_ipv6 = false
fast_mode = true
use_middle_proxy = false
# ad_tag = "..."
+ # disable_colors = false  # Disable colored output in logs (useful for files/systemd)
```

## Feature Description

The `disable_colors` parameter allows users to disable ANSI color codes in log output. This is particularly useful in the following scenarios:

1. **Systemd Services**: When running as a systemd service, colored output may not be desirable as logs are typically viewed through `journalctl` or redirected to log files.

2. **Log Files**: When redirecting output to a file, ANSI escape codes can clutter the log and make it harder to read or parse programmatically.

3. **CI/CD Pipelines**: In automated environments, colored output may interfere with log aggregation systems.

## Usage

To disable colored output in logs, add the following to your `config.toml`:

```toml
[general]
disable_colors = true
```

The default value is `false`, meaning colored output is enabled by default for interactive terminal sessions.

## Implementation Notes

- The `disable_colors` parameter is already implemented in `src/config/types.rs`
- It is part of the `GeneralConfig` struct
- The parameter is optional and defaults to `false`

## Related

This PR addresses the documentation gap for one of the 16 previously undocumented configuration parameters identified in the codebase.