### PR TITLE
feat: Add -V/--version flag to print version string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ fn parse_cli() -> (String, bool, Option<String>) {
                 eprintln!("Options:");
                 eprintln!("  --silent, -s            Suppress info logs");
                 eprintln!("  --log-level <LEVEL>     debug|verbose|normal|silent");
+                eprintln!("  --version, -V           Print version information");
                 eprintln!("  --help, -h              Show this help");
                 eprintln!();
                 eprintln!("Setup (fire-and-forget):");
@@ -90,6 +91,10 @@ fn parse_cli() -> (String, bool, Option<String>) {
                 eprintln!("    --user <NAME>          Username (default: user)");
                 eprintln!("    --config-dir <DIR>     Config directory (default: /etc/telemt)");
                 eprintln!("    --no-start             Don't start the service after install");
+                std::process::exit(0);
+            }
+            "--version" | "-V" => {
+                println!("telemt {}", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
             s if !s.starts_with('-') => {


### PR DESCRIPTION
Closes #156

## Summary
This PR adds the ability to print the version string by running  or .

## Changes
- Add handling for  and  arguments in CLI parser
- Print version to stdout using  from Cargo.toml
- Update help text to include version option

## Testing
```
$ telemt --version
telemt 3.0.4

$ telemt -V
telemt 3.0.4
```

This feature is helpful for automated update scripts and makes it easy to check the version without searching through log files.