### PR TITLE
Use mask_host for TLS emulation fetcher

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -461,10 +461,12 @@ match crate::transport::middle_proxy::fetch_proxy_secret(proxy_secret_path).awai
         cache.load_from_disk().await;
 
         let port = config.censorship.mask_port;
+        let mask_host = config.censorship.mask_host.clone()
+            .unwrap_or_else(|| config.censorship.tls_domain.clone());
         // Initial synchronous fetch to warm cache before serving clients.
         for domain in tls_domains.clone() {
             match crate::tls_front::fetcher::fetch_real_tls(
-                &domain,
+                &mask_host,
                 port,
                 &domain,
                 Duration::from_secs(5),
@@ -488,7 +490,7 @@ match crate::transport::middle_proxy::fetch_proxy_secret(proxy_secret_path).awai
                 tokio::time::sleep(Duration::from_secs(base_secs + jitter_secs)).await;
                 for domain in &domains {
                     match crate::tls_front::fetcher::fetch_real_tls(
-                        domain,
+                        &mask_host,
                         port,
                         domain,
                         Duration::from_secs(5),


### PR DESCRIPTION
## Summary

- `fetch_real_tls` accepts separate `host` (TCP connection target) and `sni` (TLS SNI) parameters, but both were being set to `domain`
- When `mask_host` is configured, it should be used as the connection host, while `domain` remains the SNI
- Fixed in both the initial cache warm-up fetch and the periodic refresh loop

## Details

If `mask_host` is not set, it falls back to `tls_domain` — preserving existing behaviour.