### PR TITLE
Add docker-image in ghrc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,8 +108,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ github.ref }}
 
   release:
     name: Create Release


### PR DESCRIPTION
Hi! I'd like to use the official image from telemnt, but unfortunately, it seems I need to build it myself on my server or push it to Docker Hub. I've added a new step to the CI/CD based on this [repository](https://github.com/remnawave/backend/blob/main/.github/workflows/build-and-push.yml#L28). If you have any suggestions for improving the PR, please let me know.

---

Привет! Я бы хотел использовать официальный образ от telemnt, но, к сожалению, вижу, что его нужно собирать самостоятельно на своем сервере или загружать на Docker Hub. Я добавил новый пункт в CI/CD на основе этого [репозитория](https://github.com/remnawave/backend/blob/main/.github/workflows/build-and-push.yml#L28). Если есть предложения по улучшению PR, пишите.
