### PR TITLE
Improve CLI help text with comprehensive options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,27 +73,36 @@ fn parse_cli() -> (String, bool, Option<String>) {
                 log_level = Some(s.trim_start_matches("--log-level=").to_string());
             }
             "--help" | "-h" => {
-                eprintln!("Usage: telemt [config.toml] [OPTIONS]");
+                eprintln!("telemt - Telegram MTProto Proxy v{}", env!("CARGO_PKG_VERSION"));
                 eprintln!();
-                eprintln!("Options:");
-                eprintln!("  --silent, -s            Suppress info logs");
-                eprintln!("  --log-level <LEVEL>     debug|verbose|normal|silent");
-                eprintln!("  --help, -h              Show this help");
+                eprintln!("USAGE:");
+                eprintln!("    telemt [CONFIG] [OPTIONS]");
+                eprintln!("    telemt --init [INIT_OPTIONS]");
                 eprintln!();
-                eprintln!("Setup (fire-and-forget):");
-                eprintln!(
-                    "  --init                  Generate config, install systemd service, start"
-                );
+                eprintln!("ARGS:");
+                eprintln!("    <CONFIG>       Path to config file (default: config.toml)");
+                eprintln!();
+                eprintln!("OPTIONS:");
+                eprintln!("    -s, --silent           Suppress info logs (equivalent to --log-level silent)");
+                eprintln!("    --log-level <LEVEL>    Set log level [possible values: debug, verbose, normal, silent]");
+                eprintln!("    -h, --help             Show this help message");
+                eprintln!("    -V, --version          Print version number");
+                eprintln!();
+                eprintln!("INIT OPTIONS (fire-and-forget setup):");
+                eprintln!("    --init                 Generate config, install systemd service, and start");
                 eprintln!("    --port <PORT>          Listen port (default: 443)");
-                eprintln!(
-                    "    --domain <DOMAIN>      TLS domain for masking (default: www.google.com)"
-                );
-                eprintln!(
-                    "    --secret <HEX>         32-char hex secret (auto-generated if omitted)"
-                );
-                eprintln!("    --user <NAME>          Username (default: user)");
+                eprintln!("    --domain <DOMAIN>      TLS domain for masking (default: www.google.com)");
+                eprintln!("    --secret <HEX>         32-char hex secret (auto-generated if omitted)");
+                eprintln!("    --user <NAME>          Username for proxy access (default: user)");
                 eprintln!("    --config-dir <DIR>     Config directory (default: /etc/telemt)");
-                eprintln!("    --no-start             Don't start the service after install");
+                eprintln!("    --no-start             Create config and service but don't start");
+                eprintln!();
+                eprintln!("EXAMPLES:");
+                eprintln!("    telemt                           # Run with default config");
+                eprintln!("    telemt /etc/telemt/config.toml   # Run with specific config");
+                eprintln!("    telemt --log-level debug         # Run with debug logging");
+                eprintln!("    telemt --init                    # Quick setup with defaults");
+                eprintln!("    telemt --init --port 8443 --user admin  # Custom setup");
                 std::process::exit(0);
             }
             "--version" | "-V" => {


### PR DESCRIPTION
## Summary

This PR improves the CLI help text to provide a more comprehensive and well-structured overview of all available command-line options.

## Changes

- Add version number to help header for quick identification
- Restructure help into clear sections: USAGE, ARGS, OPTIONS, INIT OPTIONS, EXAMPLES
- Include all command-line options with descriptions and default values
- Add usage examples for common scenarios

## New Help Output

```
telemt - Telegram MTProto Proxy v3.0.12

USAGE:
    telemt [CONFIG] [OPTIONS]
    telemt --init [INIT_OPTIONS]

ARGS:
    <CONFIG>       Path to config file (default: config.toml)

OPTIONS:
    -s, --silent           Suppress info logs (equivalent to --log-level silent)
    --log-level <LEVEL>    Set log level [possible values: debug, verbose, normal, silent]
    -h, --help             Show this help message
    -V, --version          Print version number

INIT OPTIONS (fire-and-forget setup):
    --init                 Generate config, install systemd service, and start
    --port <PORT>          Listen port (default: 443)
    --domain <DOMAIN>      TLS domain for masking (default: www.google.com)
    --secret <HEX>         32-char hex secret (auto-generated if omitted)
    --user <NAME>          Username for proxy access (default: user)
    --config-dir <DIR>     Config directory (default: /etc/telemt)
    --no-start             Create config and service but don't start

EXAMPLES:
    telemt                           # Run with default config
    telemt /etc/telemt/config.toml   # Run with specific config
    telemt --log-level debug         # Run with debug logging
    telemt --init                    # Quick setup with defaults
    telemt --init --port 8443 --user admin  # Custom setup
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation/improvement (cosmetic change, documentation update)

## Testing

- Verified the help text displays correctly with `telemt --help`
- Confirmed all options are documented with accurate descriptions