### PR TITLE
fix: add missing imports in test code

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -229,6 +229,7 @@ fn render_metrics(stats: &Stats) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http_body_util::BodyExt;
 
     #[test]
     fn test_render_metrics_format() {

--- a/src/protocol/tls.rs
+++ b/src/protocol/tls.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 
 use crate::crypto::{sha256_hmac, SecureRandom};
+use crate::error::ProxyError;
 use super::constants::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 use num_bigint::BigUint;
@@ -614,7 +615,7 @@ pub fn parse_tls_record_header(header: &[u8; 5]) -> Option<(u8, u16)> {
 ///
 /// This is useful for testing that our ServerHello is well-formed.
 #[cfg(test)]
-fn validate_server_hello_structure(data: &[u8]) -> Result<()> {
+fn validate_server_hello_structure(data: &[u8]) -> Result<(), ProxyError> {
     if data.len() < 5 {
         return Err(ProxyError::InvalidTlsRecord {
             record_type: 0,

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -497,6 +497,7 @@ impl ReplayStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     
     #[test]
     fn test_stats_shared_counters() {


### PR DESCRIPTION
## Summary

Fixes compilation errors in `cargo test --release` caused by missing imports in test modules.

## Changes

- **src/protocol/tls.rs**: Added `use crate::error::ProxyError;` import and fixed `Result<()>` to `Result<(), ProxyError>` for the `validate_server_hello_structure` test helper function
- **src/stats/mod.rs**: Added `use std::sync::Arc;` import in test module
- **src/metrics.rs**: Added `use http_body_util::BodyExt;` import in test module

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All 164 tests now pass:

```
cargo test --release
```

## Pre-flight Checklist

- [x] Code compiles correctly
- [x] All tests pass