### PR TITLE
fix: add #[cfg(test)] to unused ProxyError import

### DIFF
--- a/src/protocol/tls.rs
+++ b/src/protocol/tls.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 
 use crate::crypto::{sha256_hmac, SecureRandom};
+#[cfg(test)]
 use crate::error::ProxyError;
 use super::constants::*;
 use std::time::{SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
## Summary

- Fixed unused import warning in `src/protocol/tls.rs` by adding `#[cfg(test)]` attribute to the `ProxyError` import
- The import is only used in test code (`validate_server_hello_structure` function), so conditional compilation ensures it's only included during test builds

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified with `cargo check` that the warning is eliminated
- No functional changes, only compile-time conditional import