### PR TITLE
Add per-user ad_tag with global fallback and hot-reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "telemt"
-version = "3.0.13"
+version = "3.1.3"
 dependencies = [
  "aes",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -215,10 +215,12 @@ hello = "00000000000000000000000000000000"
 
 ```
 ### Advanced
-#### Adtag
-To use channel advertising and usage statistics from Telegram, get Adtag from [@mtproxybot](https://t.me/mtproxybot), add this parameter to section `[General]`
+#### Ad tag (per-user)
+To use channel advertising and usage statistics from Telegram, get an ad tag from [@mtproxybot](https://t.me/mtproxybot). Set it per user in `[access.user_ad_tags]` (32 hex chars):
 ```toml
-ad_tag = "00000000000000000000000000000000" # Replace zeros to your adtag from @mtproxybot
+[access.user_ad_tags]
+username1 = "11111111111111111111111111111111"  # Replace with your tag from @mtproxybot
+username2 = "22222222222222222222222222222222"
 ```
 #### Listening and Announce IPs
 To specify listening address and/or address in links, add to section `[[server.listeners]]` of config.toml:

--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,9 @@
 # === General Settings ===
 [general]
 use_middle_proxy = false
+# Global ad_tag fallback when user has no per-user tag in [access.user_ad_tags]
 # ad_tag = "00000000000000000000000000000000"
+# Per-user ad_tag in [access.user_ad_tags] (32 hex from @MTProxybot)
 
 # === Log Level ===
 # Log level: debug | verbose | normal | silent

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -532,7 +532,7 @@ impl ProxyConfig {
             )));
         }
 
-        if let Some(tag) = &self.general.ad_tag {
+        for (user, tag) in &self.access.user_ad_tags {
             let zeros = "00000000000000000000000000000000";
             if !is_valid_ad_tag(tag) {
                 return Err(ProxyError::Config(
@@ -540,7 +540,7 @@ impl ProxyConfig {
                 ));
             }
             if tag == zeros {
-                warn!("ad_tag is all zeros; register a valid proxy tag via @MTProxybot to enable sponsored channel");
+                warn!(user = %user, "user ad_tag is all zeros; register a valid proxy tag via @MTProxybot to enable sponsored channel");
             }
         }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -247,13 +247,14 @@ pub struct GeneralConfig {
     #[serde(default = "default_true")]
     pub use_middle_proxy: bool,
 
-    #[serde(default)]
-    pub ad_tag: Option<String>,
-
     /// Path to proxy-secret binary file (auto-downloaded if absent).
     /// Infrastructure secret from https://core.telegram.org/getProxySecret.
     #[serde(default = "default_proxy_secret_path")]
     pub proxy_secret_path: Option<String>,
+
+    /// Global ad_tag (32 hex chars from @MTProxybot). Fallback when user has no per-user tag in access.user_ad_tags.
+    #[serde(default)]
+    pub ad_tag: Option<String>,
 
     /// Public IP override for middle-proxy NAT environments.
     /// When set, this IP is used in ME key derivation and RPC_PROXY_REQ "our_addr".
@@ -807,6 +808,10 @@ pub struct AccessConfig {
     #[serde(default = "default_access_users")]
     pub users: HashMap<String, String>,
 
+    /// Per-user ad_tag (32 hex chars from @MTProxybot).
+    #[serde(default)]
+    pub user_ad_tags: HashMap<String, String>,
+
     #[serde(default)]
     pub user_max_tcp_conns: HashMap<String, usize>,
 
@@ -833,6 +838,7 @@ impl Default for AccessConfig {
     fn default() -> Self {
         Self {
             users: default_access_users(),
+            user_ad_tags: HashMap::new(),
             user_max_tcp_conns: HashMap::new(),
             user_expirations: HashMap::new(),
             user_data_quota: HashMap::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -448,7 +448,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             info!("Middle-proxy STUN probing disabled by network.stun_use=false");
         }
 
-        // ad_tag (proxy_tag) for advertising
+        // Global ad_tag (pool default). Used when user has no per-user tag in access.user_ad_tags.
         let proxy_tag = config
             .general
             .ad_tag

--- a/src/transport/middle_proxy/send.rs
+++ b/src/transport/middle_proxy/send.rs
@@ -18,6 +18,7 @@ use rand::seq::SliceRandom;
 use super::registry::ConnMeta;
 
 impl MePool {
+    /// Send RPC_PROXY_REQ. `tag_override`: per-user ad_tag (from access.user_ad_tags); if None, uses pool default.
     pub async fn send_proxy_req(
         self: &Arc<Self>,
         conn_id: u64,
@@ -26,13 +27,15 @@ impl MePool {
         our_addr: SocketAddr,
         data: &[u8],
         proto_flags: u32,
+        tag_override: Option<&[u8]>,
     ) -> Result<()> {
+        let tag = tag_override.or(self.proxy_tag.as_deref());
         let payload = build_proxy_req_payload(
             conn_id,
             client_addr,
             our_addr,
             data,
-            self.proxy_tag.as_deref(),
+            tag,
             proto_flags,
         );
         let meta = ConnMeta {


### PR DESCRIPTION
- Per-user ad_tag in [access.user_ad_tags], global fallback in general.ad_tag
- User tag overrides global; if no user tag, general.ad_tag is used
- Both general.ad_tag and user_ad_tags support hot-reload (no restart)