### PR TITLE
fix:docker-compose.yml bind metrics port to localhost only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     restart: unless-stopped
     ports:
       - "443:443"
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     # Allow caching 'proxy-secret' in read-only container
     working_dir: /run/telemt
     volumes:


### PR DESCRIPTION
Since metrics are intended for local use only, there is no reason to expose port 9090 on all interfaces. This change binds it to 127.0.0.1 instead.