### PR TITLE
Update telemt.service

### DIFF
--- a/telemt.service
+++ b/telemt.service
@@ -5,10 +5,12 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/bin
+WorkingDirectory=/etc/telemt
 ExecStart=/bin/telemt /etc/telemt.toml
 Restart=on-failure
-LimitNOFILE=65536
+LimitNOFILE=262144
+TasksMax=8192
+MemoryAccounting=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Updated service dependencies and added SELinux context.

`network-online.target` is required to get the ip address and check telegram servers