### PR TITLE
feat: configurable max_connections limit

### DIFF
--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -147,6 +147,10 @@ pub(crate) fn default_proxy_protocol_header_timeout_ms() -> u64 {
     500
 }
 
+pub(crate) fn default_server_max_connections() -> u32 {
+    10_000
+}
+
 pub(crate) fn default_prefer_4() -> u8 {
     4
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1167,6 +1167,11 @@ pub struct ServerConfig {
 
     #[serde(default)]
     pub listeners: Vec<ListenerConfig>,
+
+    /// Maximum number of concurrent client connections.
+    /// 0 means unlimited.
+    #[serde(default = "default_server_max_connections")]
+    pub max_connections: u32,
 }
 
 impl Default for ServerConfig {
@@ -1184,6 +1189,7 @@ impl Default for ServerConfig {
             metrics_whitelist: default_metrics_whitelist(),
             api: ApiConfig::default(),
             listeners: Vec::new(),
+            max_connections: default_server_max_connections(),
         }
     }
 }

--- a/src/maestro/mod.rs
+++ b/src/maestro/mod.rs
@@ -349,8 +349,13 @@ pub async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let beobachten = Arc::new(BeobachtenStore::new());
     let rng = Arc::new(SecureRandom::new());
 
-    // Connection concurrency limit
-    let max_connections = Arc::new(Semaphore::new(10_000));
+    // Connection concurrency limit (0 = unlimited)
+    let max_connections_limit = if config.server.max_connections == 0 {
+        Semaphore::MAX_PERMITS
+    } else {
+        config.server.max_connections as usize
+    };
+    let max_connections = Arc::new(Semaphore::new(max_connections_limit));
 
     let me2dc_fallback = config.general.me2dc_fallback;
     let me_init_retry_attempts = config.general.me_init_retry_attempts;


### PR DESCRIPTION
## Summary

Currently the concurrent connection limit is hardcoded to 10,000 (`Semaphore::new(10_000)` in `maestro/mod.rs`). This makes it impossible to tune without rebuilding from source.

This PR adds a `max_connections` option to the `[server]` config section:

- **Default:** `10000` (same behavior as before, no breaking changes)
- **Any positive value:** sets that as the limit
- **`0`:** disables the limit entirely (uses `Semaphore::MAX_PERMITS`)

### Usage

```toml
[server]
max_connections = 0       # unlimited
# max_connections = 50000 # or a specific limit
```

### Changes

- `src/config/defaults.rs` — default value function
- `src/config/types.rs` — new field in `ServerConfig`
- `src/maestro/mod.rs` — read from config instead of hardcoded value