### PR TITLE
fix(docker): expose port 9091 and allow external API access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ USER telemt
 
 EXPOSE 443
 EXPOSE 9090
+EXPOSE 9091
 
 ENTRYPOINT ["/app/telemt"]
 CMD ["config.toml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "443:443"
       - "127.0.0.1:9090:9090"
+      - "127.0.0.1:9091:9091"
     # Allow caching 'proxy-secret' in read-only container
     working_dir: /run/telemt
     volumes:

--- a/docs/QUICK_START_GUIDE.en.md
+++ b/docs/QUICK_START_GUIDE.en.md
@@ -181,6 +181,8 @@ docker compose down
 docker build -t telemt:local .
 docker run --name telemt --restart unless-stopped \
   -p 443:443 \
+  -p 9090:9090 \
+  -p 9091:9091 \
   -e RUST_LOG=info \
   -v "$PWD/config.toml:/app/config.toml:ro" \
   --read-only \

--- a/docs/QUICK_START_GUIDE.ru.md
+++ b/docs/QUICK_START_GUIDE.ru.md
@@ -183,6 +183,8 @@ docker compose down
 docker build -t telemt:local .
 docker run --name telemt --restart unless-stopped \
   -p 443:443 \
+  -p 9090:9090 \
+  -p 9091:9091 \
   -e RUST_LOG=info \
   -v "$PWD/config.toml:/app/config.toml:ro" \
   --read-only \


### PR DESCRIPTION
Add 9091 port mapping to compose.yml to make the REST API reachable from outside the container. Previously only port 9090 (metrics) was published, making the documented curl commands non-functional.

fixes #434