### PR TITLE
feat(api): add reset-octets endpoints for periodic quota management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "telemt"
-version = "3.3.25"
+version = "3.3.28"
 dependencies = [
  "aes",
  "anyhow",

--- a/docs/API.md
+++ b/docs/API.md
@@ -1058,6 +1058,8 @@ Link generation uses active config and enabled modes:
 | `PATCH /v1/users/{username}` | Partial update of provided fields only. Missing fields remain unchanged. Current implementation persists full config document on success. |
 | `POST /v1/users/{username}/rotate-secret` | Currently returns `404` in runtime route matcher; request schema is reserved for intended behavior. |
 | `DELETE /v1/users/{username}` | Deletes only specified user, removes this user from related optional `access.user_*` maps, blocks last-user deletion, and atomically updates only related `access.*` TOML tables. |
+| `POST /v1/users/{username}/reset-octets` | Resets the per-user octet counters (`octets_from_client` and `octets_to_client`) to zero. Returns `{ "username": "...", "octets_reset": true }`. Useful for implementing periodic (monthly/daily) quota resets without restarting the proxy. |
+| `POST /v1/users/reset-octets` | Resets octet counters for **all** tracked users. Returns `{ "users_reset": N }`. |
 
 All mutating endpoints:
 - Respect `read_only` mode.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -372,6 +372,19 @@ async fn handle(
                 .await;
                 Ok(success_response(StatusCode::OK, users, revision))
             }
+            ("POST", "/v1/users/reset-octets") => {
+                let count = shared.stats.reset_all_user_octets();
+                shared.runtime_events.record(
+                    "api.users.reset_octets.ok",
+                    format!("users_reset={}", count),
+                );
+                let revision = current_revision(&shared.config_path).await?;
+                Ok(success_response(
+                    StatusCode::OK,
+                    model::ResetAllOctetsResponse { users_reset: count },
+                    revision,
+                ))
+            }
             ("POST", "/v1/users") => {
                 if api_cfg.read_only {
                     return Ok(error_response(
@@ -522,6 +535,37 @@ async fn handle(
                             format!("username={}", base_user),
                         );
                         return Ok(success_response(StatusCode::OK, data, revision));
+                    }
+                    // POST /v1/users/{username}/reset-octets
+                    if method == Method::POST
+                        && let Some(base_user) = user.strip_suffix("/reset-octets")
+                        && !base_user.is_empty()
+                        && !base_user.contains('/')
+                    {
+                        let found = shared.stats.reset_user_octets(base_user);
+                        shared.runtime_events.record(
+                            if found { "api.user.reset_octets.ok" } else { "api.user.reset_octets.not_found" },
+                            format!("username={}", base_user),
+                        );
+                        if !found {
+                            return Ok(error_response(
+                                request_id,
+                                ApiFailure::new(
+                                    StatusCode::NOT_FOUND,
+                                    "user_not_found",
+                                    &format!("No stats entry for user '{}'", base_user),
+                                ),
+                            ));
+                        }
+                        let revision = current_revision(&shared.config_path).await?;
+                        return Ok(success_response(
+                            StatusCode::OK,
+                            model::ResetOctetsResponse {
+                                username: base_user.to_string(),
+                                octets_reset: true,
+                            },
+                            revision,
+                        ));
                     }
                     if method == Method::POST {
                         return Ok(error_response(

--- a/src/api/model.rs
+++ b/src/api/model.rs
@@ -458,6 +458,17 @@ pub(super) struct CreateUserRequest {
     pub(super) max_unique_ips: Option<usize>,
 }
 
+#[derive(Serialize)]
+pub(super) struct ResetOctetsResponse {
+    pub(super) username: String,
+    pub(super) octets_reset: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct ResetAllOctetsResponse {
+    pub(super) users_reset: usize,
+}
+
 #[derive(Deserialize)]
 pub(super) struct PatchUserRequest {
     pub(super) secret: Option<String>,

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1745,6 +1745,29 @@ impl Stats {
             .unwrap_or(0)
     }
     
+
+    /// Reset per-user octet counters to zero (both from_client and to_client).
+    /// Used by the API to implement periodic quota resets without restarting the proxy.
+    pub fn reset_user_octets(&self, user: &str) -> bool {
+        if let Some(entry) = self.user_stats.get(user) {
+            entry.octets_from_client.store(0, Ordering::Relaxed);
+            entry.octets_to_client.store(0, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Reset octet counters for all tracked users.
+    pub fn reset_all_user_octets(&self) -> usize {
+        let mut count = 0;
+        for entry in self.user_stats.iter() {
+            entry.octets_from_client.store(0, Ordering::Relaxed);
+            entry.octets_to_client.store(0, Ordering::Relaxed);
+            count += 1;
+        }
+        count
+    }
     pub fn get_handshake_timeouts(&self) -> u64 { self.handshake_timeouts.load(Ordering::Relaxed) }
     pub fn get_upstream_connect_attempt_total(&self) -> u64 {
         self.upstream_connect_attempt_total.load(Ordering::Relaxed)


### PR DESCRIPTION
## Summary

Adds API endpoints to reset per-user octet (byte) counters at runtime, without restarting the proxy. This enables external management tools to implement periodic quota resets (monthly, daily, weekly).

**Closes #510**

## New Endpoints

### `POST /v1/users/{username}/reset-octets`
Resets octet counters for a single user.

```bash
curl -X POST http://127.0.0.1:9091/v1/users/alice/reset-octets
```

Response:
```json
{
  "ok": true,
  "data": {
    "username": "alice",
    "octets_reset": true
  },
  "revision": "..."
}
```

### `POST /v1/users/reset-octets`
Resets octet counters for all tracked users.

```bash
curl -X POST http://127.0.0.1:9091/v1/users/reset-octets
```

Response:
```json
{
  "ok": true,
  "data": {
    "users_reset": 5
  },
  "revision": "..."
}
```

## Use Case

Management wrappers like [MTProxyMax](https://github.com/SamNet-dev/MTProxyMax) need to implement monthly quotas for users. Currently `user_data_quota` is lifetime-only — once the cap is hit, the user is permanently blocked.

With this endpoint, a cron job can reset counters on a schedule:
```bash
# Reset all users on the 1st of each month
0 0 1 * * curl -X POST http://127.0.0.1:9091/v1/users/reset-octets
```

## Changes

| File | Change |
|------|--------|
| `src/stats/mod.rs` | Added `reset_user_octets()` and `reset_all_user_octets()` — stores 0 into `AtomicU64` counters |
| `src/api/mod.rs` | Added route handlers following existing patterns (event recording, revision tracking) |
| `src/api/model.rs` | Added `ResetOctetsResponse` and `ResetAllOctetsResponse` structs |
| `docs/API.md` | Documented both endpoints |

## Design Decisions

- **Direct zero vs baseline offset**: Chose direct `.store(0)` for simplicity. The alternative (storing a baseline and computing `current - baseline`) preserves Prometheus monotonicity but adds complexity to every read path. Since this is an explicit admin action, the discontinuity is expected.
- **No auth beyond existing API auth**: Uses the same whitelist + auth_header mechanism as all other endpoints.
- **No config file mutation**: Octets are runtime-only stats, so no `mutation_lock` or `If-Match` needed.
- **Stats-only, not config**: The `user_data_quota` cap itself is unchanged — only the counter against which it's compared is reset.

## Test Plan

- [x] `cargo check` — compiles cleanly (0 new warnings)
- [x] `cargo test` — 327 tests pass, 0 failures
- [ ] Manual test: create user, send traffic, call reset endpoint, verify `total_octets` returns 0
- [ ] Verify quota enforcement works correctly after reset (user can connect again)
- [ ] Verify Prometheus metrics reflect the reset