### PR TITLE
docs: fix typo in ru QUICK_START

### DIFF
--- a/docs/QUICK_START_GUIDE.ru.md
+++ b/docs/QUICK_START_GUIDE.ru.md
@@ -178,7 +178,7 @@ docker compose down
 > - По умолчанию публикуются порты 443:443, а контейнер запускается со сброшенными привилегиями (добавлена только `NET_BIND_SERVICE`)  
 > - Если вам действительно нужна сеть хоста (обычно это требуется только для некоторых конфигураций IPv6), раскомментируйте `network_mode: host`
 
-**Запуск в Docker Compose**
+**Запуск без Docker Compose**
 ```bash
 docker build -t telemt:local .
 docker run --name telemt --restart unless-stopped \


### PR DESCRIPTION
Matching the english translation, current text doesn't make sense