### PR TITLE
[codex] Set content type on metrics 404 responses

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -19,6 +19,7 @@ use crate::stats::Stats;
 use crate::stats::beobachten::BeobachtenStore;
 use crate::transport::{ListenOptions, create_listener};
 
+/// Serves the Prometheus metrics and beobachten plaintext endpoints.
 pub async fn serve(
     port: u16,
     listen: Option<String>,
@@ -205,6 +206,7 @@ async fn handle<B>(
 
     let resp = Response::builder()
         .status(StatusCode::NOT_FOUND)
+        .header("content-type", "text/plain; charset=utf-8")
         .body(Full::new(Bytes::from("Not Found\n")))
         .unwrap();
     Ok(resp)
@@ -2782,5 +2784,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp404.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            resp404.headers().get("content-type").unwrap(),
+            "text/plain; charset=utf-8"
+        );
     }
 }


### PR DESCRIPTION
This change fixes a small response-consistency bug in the metrics handler.

Both successful plaintext endpoints in `src/metrics.rs` (`/metrics` and `/beobachten`) explicitly return a `content-type` header, but the `404` branch returned a plaintext body without one. That made the same handler inconsistent across its three response paths and left clients to infer the body type on misses.

The root cause was simply that the `NOT_FOUND` response builder omitted the header that the other plaintext branches already set.

The fix adds `content-type: text/plain; charset=utf-8` to the `404` response and extends the existing endpoint integration test to assert that header. This keeps the change local, objective, and covered by the test that already exercises the not-found path.

Validation was performed with `cargo test test_endpoint_integration -- --nocapture`.
