### PR TITLE
[codex] Use canonical links config in init output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -186,8 +186,6 @@ fn generate_config(username: &str, secret: &str, port: u16, domain: &str) -> Str
         r#"# Telemt MTProxy — auto-generated config
 # Re-run `telemt --init` to regenerate
 
-show_link = ["{username}"]
-
 [general]
 # prefer_ipv6 is deprecated; use [network].prefer
 prefer_ipv6 = false
@@ -218,6 +216,9 @@ multipath = false
 classic = false
 secure = false
 tls = true
+
+[general.links]
+show = ["{username}"]
 
 [server]
 port = {port}


### PR DESCRIPTION
This change updates the `telemt --init` config template to emit the canonical links configuration shape.

The generated config previously wrote the legacy top-level `show_link = [...]` field. The repository’s current config format, example `config.toml`, and documentation all use `[general.links]` with `show = ...` instead. The loader also contains explicit migration logic that copies the legacy `show_link` field into `general.links.show`, which is strong internal proof that the init template is emitting an outdated format.

The fix updates the generated template in `src/cli.rs` to write:

```toml
[general.links]
show = ["user"]
```

instead of the legacy top-level field. This keeps newly generated configs aligned with the canonical config shape already used elsewhere in the repository and avoids relying on migration logic for fresh output.

Validation was performed with `cargo run -- --init --config-dir "$tmpdir" --no-start` and inspection of the generated `config.toml`.
