### PR TITLE
[codex] Mark prefer_ipv6 deprecated in config docs

### DIFF
--- a/docs/CONFIG_PARAMS.en.md
+++ b/docs/CONFIG_PARAMS.en.md
@@ -20,7 +20,7 @@ This document lists all configuration keys accepted by `config.toml`.
 | Parameter | Type | Default | Constraints / validation | Description |
 |---|---|---|---|---|
 | data_path | `String \| null` | `null` | — | Optional runtime data directory path. |
-| prefer_ipv6 | `bool` | `false` | — | Prefer IPv6 where applicable in runtime logic. |
+| prefer_ipv6 | `bool` | `false` | Deprecated. Use `network.prefer`. | Legacy IPv6 preference switch kept for backward compatibility. |
 | fast_mode | `bool` | `true` | — | Enables fast-path optimizations for traffic processing. |
 | use_middle_proxy | `bool` | `true` | none | Enables ME transport mode; if `false`, runtime falls back to direct DC routing. |
 | proxy_secret_path | `String \| null` | `"proxy-secret"` | Path may be `null`. | Path to Telegram infrastructure proxy-secret file used by ME handshake logic. |


### PR DESCRIPTION
This change fixes a configuration reference mismatch for `general.prefer_ipv6`.

The loader treats `prefer_ipv6` as a deprecated legacy field and emits a warning directing users to `network.prefer`, but `docs/CONFIG_PARAMS.en.md` still described it as a normal parameter without any deprecation note. That makes the reference inaccurate for users who rely on the docs to understand the current canonical config shape.

The fix updates the `prefer_ipv6` entry in the config reference to mark it as deprecated and point users to `network.prefer` instead. This keeps the documentation aligned with the actual loader behavior already implemented in `src/config/load.rs`.

Validation for this change is repository-internal consistency: the updated docs now match the existing deprecation warning in the loader (`prefer_ipv6 is deprecated, use [network].prefer = 6`).
