### PR TITLE
align Linux docs with config.toml runtime path

### DIFF
--- a/docs/FAQ.en.md
+++ b/docs/FAQ.en.md
@@ -3,7 +3,7 @@
 1. Go to @MTProxybot bot.
 2. Enter the command `/newproxy`
 3. Send the server IP and port. For example: 1.2.3.4:443
-4. Open the config `nano /etc/telemt/telemt.toml`.
+4. Open the config `nano /etc/telemt/config.toml`.
 5. Copy and send the user secret from the [access.users] section to the bot.
 6. Copy the tag received from the bot. For example 1234567890abcdef1234567890abcdef.
 > [!WARNING]
@@ -46,7 +46,7 @@ This parameter limits how many unique IPs can use 1 link simultaneously. If one 
 ## How to create multiple different links
 
 1. Generate the required number of secrets `openssl rand -hex 16`
-2. Open the config `nano /etc/telemt/telemt.toml`
+2. Open the config `nano /etc/telemt/config.toml`
 3. Add new users.
 ```toml
 [access.users]
@@ -62,7 +62,7 @@ curl -s http://127.0.0.1:9091/v1/users | jq
 
 ## How to view metrics
 
-1. Open the config `nano /etc/telemt/telemt.toml`
+1. Open the config `nano /etc/telemt/config.toml`
 2. Add the following parameters
 ```toml
 [server]

--- a/docs/FAQ.ru.md
+++ b/docs/FAQ.ru.md
@@ -3,7 +3,7 @@
 1. Зайти в бота @MTProxybot.
 2. Ввести команду `/newproxy`
 3. Отправить IP и порт сервера. Например: 1.2.3.4:443
-4. Открыть конфиг `nano /etc/telemt/telemt.toml`.
+4. Открыть конфиг `nano /etc/telemt/config.toml`.
 5. Скопировать и отправить боту секрет пользователя из раздела [access.users].
 6. Скопировать полученный tag у бота. Например 1234567890abcdef1234567890abcdef.
 > [!WARNING]
@@ -46,7 +46,7 @@ hello = 1
 ## Как сделать несколько разных ссылок
 
 1. Сгенерируйте нужное число секретов `openssl rand -hex 16`
-2. Открыть конфиг `nano /etc/telemt/telemt.toml`
+2. Открыть конфиг `nano /etc/telemt/config.toml`
 3. Добавить новых пользователей.
 ```toml
 [access.users]
@@ -62,7 +62,7 @@ curl -s http://127.0.0.1:9091/v1/users | jq
 
 ## Как посмотреть метрики
 
-1. Открыть конфиг `nano /etc/telemt/telemt.toml`
+1. Открыть конфиг `nano /etc/telemt/config.toml`
 2. Добавить следующие параметры
 ```toml
 [server]

--- a/docs/QUICK_START_GUIDE.en.md
+++ b/docs/QUICK_START_GUIDE.en.md
@@ -48,7 +48,7 @@ Save the obtained result somewhere. You will need it later!
 
 ---
 
-**1. Place your config to /etc/telemt/telemt.toml**
+**1. Place your config to /etc/telemt/config.toml**
 
 Create config directory:
 ```bash
@@ -57,7 +57,7 @@ mkdir /etc/telemt
 
 Open nano
 ```bash
-nano /etc/telemt/telemt.toml
+nano /etc/telemt/config.toml
 ```
 paste your config
 
@@ -124,7 +124,7 @@ Type=simple
 User=telemt
 Group=telemt
 WorkingDirectory=/opt/telemt
-ExecStart=/bin/telemt /etc/telemt/telemt.toml
+ExecStart=/bin/telemt /etc/telemt/config.toml
 Restart=on-failure
 LimitNOFILE=65536
 AmbientCapabilities=CAP_NET_BIND_SERVICE

--- a/docs/QUICK_START_GUIDE.ru.md
+++ b/docs/QUICK_START_GUIDE.ru.md
@@ -48,7 +48,7 @@ python3 -c 'import os; print(os.urandom(16).hex())'
 
 ---
 
-**1. Поместите свою конфигурацию в файл /etc/telemt/telemt.toml**
+**1. Поместите свою конфигурацию в файл /etc/telemt/config.toml**
 
 Создаём директорию для конфига:
 ```bash
@@ -57,7 +57,7 @@ mkdir /etc/telemt
 
 Открываем nano
 ```bash
-nano /etc/telemt/telemt.toml
+nano /etc/telemt/config.toml
 ```
 Вставьте свою конфигурацию
 
@@ -124,7 +124,7 @@ Type=simple
 User=telemt
 Group=telemt
 WorkingDirectory=/opt/telemt
-ExecStart=/bin/telemt /etc/telemt/telemt.toml
+ExecStart=/bin/telemt /etc/telemt/config.toml
 Restart=on-failure
 LimitNOFILE=65536
 AmbientCapabilities=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
## Summary
- align the Linux FAQ and quick-start docs with the runtime default config filename
- update the Linux systemd example to use `/etc/telemt/config.toml`
- keep the separate OpenBSD path untouched

## Verification
- compared Linux docs against `src/maestro/helpers.rs` default CLI config path
- compared Linux docs against `src/cli.rs` init output path
- confirmed `docs/OPENBSD.en.md` still documents its separate flow
