### PR TITLE
Add an important proxy_protocol_trusted_cidrs option description

### DIFF
--- a/docs/CONFIG_PARAMS.en.md
+++ b/docs/CONFIG_PARAMS.en.md
@@ -198,6 +198,7 @@ This document lists all configuration keys accepted by `config.toml`.
 | listen_tcp | `bool \| null` | `null` (auto) | — | Explicit TCP listener enable/disable override. |
 | proxy_protocol | `bool` | `false` | — | Enables HAProxy PROXY protocol parsing on incoming client connections. |
 | proxy_protocol_header_timeout_ms | `u64` | `500` | Must be `> 0`. | Timeout for PROXY protocol header read/parse (ms). |
+| proxy_protocol_trusted_cidrs | `IpNetwork[]` | `null` | — | CIDRS that are allowed to send PROXY protocol header in the incoming request. |
 | metrics_port | `u16 \| null` | `null` | — | Metrics endpoint port (enables metrics listener). |
 | metrics_listen | `String \| null` | `null` | — | Full metrics bind address (`IP:PORT`), overrides `metrics_port`. |
 | metrics_whitelist | `IpNetwork[]` | `["127.0.0.1/32", "::1/128"]` | — | CIDR whitelist for metrics endpoint access. |


### PR DESCRIPTION
I've added a basic `proxy_protocol_trusted_cidrs` option description.
Without this option if you have `proxy_protocol = true` in your `[server]` section without that option filled with as at least `proxy_protocol_trusted_cidrs = ["127.0.0.0/8"]` you'll fail at any connection:
```
2026-03-22T21:01:47.326984Z DEBUG telemt::proxy::client: New connection peer=127.0.0.1:49992
2026-03-22T21:01:47.327013Z  WARN telemt::proxy::client: Rejecting PROXY protocol header from untrusted source peer=127.0.0.1:49992 trusted=[]
2026-03-22T21:01:47.327028Z DEBUG telemt::proxy::client: Handshake failed peer=127.0.0.1:49992 error=Invalid proxy protocol header
2026-03-22T21:01:47.327032Z  WARN telemt::maestro::listeners: Connection closed with error peer=127.0.0.1:49992 error=Invalid proxy protocol header
```
That because by default the value of this option is [empty](https://github.com/telemt/telemt/blob/e35d69c61fe09a20f40602af883bf68ece1d772b/src/config/types.rs#L1244), and the [code](https://github.com/telemt/telemt/blob/e35d69c61fe09a20f40602af883bf68ece1d772b/src/proxy/client.rs#L707) rejects all PROXY protocol connections, making PROXY protocol unusable (as in case with HAProxy on front of telemt for example).
Looks like the proper fix is to assign a default sane value of `["127.0.0.0/8"]` to that option in code. But for now let's atleast document it.
There is [another example of using proxy_protocol in docs](https://github.com/telemt/telemt/blob/e35d69c61fe09a20f40602af883bf68ece1d772b/docs/VPS_DOUBLE_HOP.en.md?plain=1#L170) at the main branch, but this document is absent in 'flow' branch, and as I'm obeying [contributing guidelines](https://github.com/telemt/telemt/blob/e35d69c61fe09a20f40602af883bf68ece1d772b/CONTRIBUTING.md?plain=1#L11) I can't fix this right away as I'm staying away from making a pull request to the main branch, maybe a more distinguished contributor can fix that?