### PR TITLE
Fix Docker XZ extraction and runtime libgcc dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     binutils \
     curl \
     ca-certificates \
+    xz-utils \
     && rm -rf /var/lib/apt/lists/* \
     \
     # install UPX from Telemt releases
@@ -62,6 +63,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     iproute2 \
     busybox \
+    libgcc-s1 \
     && rm -rf /var/lib/apt/lists/*
 
 # ==========================
@@ -86,7 +88,7 @@ CMD ["config.toml"]
 # ==========================
 # Stage 5: Production (distroless)
 # ==========================
-FROM gcr.io/distroless/base-debian12 AS prod
+FROM gcr.io/distroless/cc-debian12 AS prod
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- add xz-utils to the minimal compression stage so the UPX toolchain tar.xz archive can be extracted reliably
- add libgcc-s1 to the debug base image for the reported libgcc_s.so.1 runtime dependency
- switch the production runtime from distroless base-debian12 to distroless cc-debian12 so the production image includes the standard runtime libraries required by the binary

## Verification
- reasoning-based consistency check only
- Docker daemon was unavailable in this environment, so docker build and container runtime checks could not be executed locally

Closes #542