### PR TITLE
Update release profile settings for better optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,4 +83,6 @@ name = "crypto_bench"
 harness = false
 
 [profile.release]
-lto = "thin"
+lto = "fat"
+codegen-units = 1
+


### PR DESCRIPTION
changed lto to fat

**lto=thin**

glibc 24 MB
after strip 19MB

musl 24 MB
after strip - 20 MB

**lto=fat:**

glibc 17MB
after strip 15 MB

musl 17 MB
after strip - 15 MB