### PR TITLE
Configure mask timeouts

### DIFF
--- a/docs/Config_params/CONFIG_PARAMS.en.md
+++ b/docs/Config_params/CONFIG_PARAMS.en.md
@@ -2498,6 +2498,8 @@ Note: This section also accepts the legacy alias `[server.admin_api]` (same sche
 | [`mask_shape_above_cap_blur`](#cfg-censorship-mask_shape_above_cap_blur) | `bool` | `false` |
 | [`mask_shape_above_cap_blur_max_bytes`](#cfg-censorship-mask_shape_above_cap_blur_max_bytes) | `usize` | `512` |
 | [`mask_relay_max_bytes`](#cfg-censorship-mask_relay_max_bytes) | `usize` | `5242880` |
+| [`mask_relay_timeout_ms`](#cfg-censorship-mask_relay_timeout_ms) | `u64` | `60_000` |
+| [`mask_relay_idle_timeout_ms`](#cfg-censorship-mask_relay_idle_timeout_ms) | `u64` | `5_000` |
 | [`mask_classifier_prefetch_timeout_ms`](#cfg-censorship-mask_classifier_prefetch_timeout_ms) | `u64` | `5` |
 | [`mask_timing_normalization_enabled`](#cfg-censorship-mask_timing_normalization_enabled) | `bool` | `false` |
 | [`mask_timing_normalization_floor_ms`](#cfg-censorship-mask_timing_normalization_floor_ms) | `u64` | `0` |
@@ -2767,6 +2769,26 @@ Note: This section also accepts the legacy alias `[server.admin_api]` (same sche
     ```toml
     [censorship]
     mask_relay_max_bytes = 5242880
+    ```
+## "cfg-censorship-mask_relay_timeout_ms"
+- `mask_relay_timeout_ms`
+  - **Constraints / validation**: Should be `>= mask_relay_idle_timeout_ms`.
+  - **Description**: Wall-clock cap for the full masking relay on non-MTProto fallback paths. Raise when the mask target is a long-lived service (e.g. WebSocket). Default: 60 000 ms (1 minute).
+  - **Example**:
+
+    ```toml
+    [censorship]
+    mask_relay_timeout_ms = 60000
+    ```
+## "cfg-censorship-mask_relay_idle_timeout_ms"
+- `mask_relay_idle_timeout_ms`
+  - **Constraints / validation**: Should be `<= mask_relay_timeout_ms`.
+  - **Description**: Per-read idle timeout on masking relay and drain paths. Limits resource consumption by slow-loris attacks and port scanners. A read call stalling beyond this value is treated as an abandoned connection. Default: 5 000 ms (5 s).
+  - **Example**:
+
+    ```toml
+    [censorship]
+    mask_relay_idle_timeout_ms = 5000
     ```
 ## "cfg-censorship-mask_classifier_prefetch_timeout_ms"
 - `mask_classifier_prefetch_timeout_ms`

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -615,6 +615,26 @@ pub(crate) fn default_mask_relay_max_bytes() -> usize {
     32 * 1024
 }
 
+#[cfg(not(test))]
+pub(crate) fn default_mask_relay_timeout_ms() -> u64 {
+    60_000
+}
+
+#[cfg(test)]
+pub(crate) fn default_mask_relay_timeout_ms() -> u64 {
+    200
+}
+
+#[cfg(not(test))]
+pub(crate) fn default_mask_relay_idle_timeout_ms() -> u64 {
+    5_000
+}
+
+#[cfg(test)]
+pub(crate) fn default_mask_relay_idle_timeout_ms() -> u64 {
+    100
+}
+
 pub(crate) fn default_mask_classifier_prefetch_timeout_ms() -> u64 {
     5
 }

--- a/src/config/hot_reload.rs
+++ b/src/config/hot_reload.rs
@@ -611,6 +611,8 @@ fn warn_non_hot_changes(old: &ProxyConfig, new: &ProxyConfig, non_hot_changed: b
         || old.censorship.mask_shape_above_cap_blur_max_bytes
             != new.censorship.mask_shape_above_cap_blur_max_bytes
         || old.censorship.mask_relay_max_bytes != new.censorship.mask_relay_max_bytes
+        || old.censorship.mask_relay_timeout_ms != new.censorship.mask_relay_timeout_ms
+        || old.censorship.mask_relay_idle_timeout_ms != new.censorship.mask_relay_idle_timeout_ms
         || old.censorship.mask_classifier_prefetch_timeout_ms
             != new.censorship.mask_classifier_prefetch_timeout_ms
         || old.censorship.mask_timing_normalization_enabled

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1710,6 +1710,19 @@ pub struct AntiCensorshipConfig {
     #[serde(default = "default_mask_relay_max_bytes")]
     pub mask_relay_max_bytes: usize,
 
+    /// Wall-clock cap for the full masking relay on non-MTProto fallback paths.
+    /// Raise when the mask target is a long-lived service (e.g. WebSocket).
+    /// Default: 60 000 ms (60 s).
+    #[serde(default = "default_mask_relay_timeout_ms")]
+    pub mask_relay_timeout_ms: u64,
+
+    /// Per-read idle timeout on masking relay and drain paths.
+    /// Limits resource consumption by slow-loris attacks and port scanners.
+    /// A read call stalling beyond this is treated as an abandoned connection.
+    /// Default: 5 000 ms (5 s).
+    #[serde(default = "default_mask_relay_idle_timeout_ms")]
+    pub mask_relay_idle_timeout_ms: u64,
+
     /// Prefetch timeout (ms) for extending fragmented masking classifier window.
     #[serde(default = "default_mask_classifier_prefetch_timeout_ms")]
     pub mask_classifier_prefetch_timeout_ms: u64,
@@ -1755,6 +1768,8 @@ impl Default for AntiCensorshipConfig {
             mask_shape_above_cap_blur: default_mask_shape_above_cap_blur(),
             mask_shape_above_cap_blur_max_bytes: default_mask_shape_above_cap_blur_max_bytes(),
             mask_relay_max_bytes: default_mask_relay_max_bytes(),
+            mask_relay_timeout_ms: default_mask_relay_timeout_ms(),
+            mask_relay_idle_timeout_ms: default_mask_relay_idle_timeout_ms(),
             mask_classifier_prefetch_timeout_ms: default_mask_classifier_prefetch_timeout_ms(),
             mask_timing_normalization_enabled: default_mask_timing_normalization_enabled(),
             mask_timing_normalization_floor_ms: default_mask_timing_normalization_floor_ms(),

--- a/src/proxy/masking.rs
+++ b/src/proxy/masking.rs
@@ -28,14 +28,10 @@ use tracing::debug;
 const MASK_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const MASK_TIMEOUT: Duration = Duration::from_millis(50);
-/// Maximum duration for the entire masking relay.
-/// Limits resource consumption from slow-loris attacks and port scanners.
-#[cfg(not(test))]
-const MASK_RELAY_TIMEOUT: Duration = Duration::from_secs(60);
+/// Maximum duration for the entire masking relay under test (replaced by config at runtime).
 #[cfg(test)]
 const MASK_RELAY_TIMEOUT: Duration = Duration::from_millis(200);
-#[cfg(not(test))]
-const MASK_RELAY_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Per-read idle timeout for masking relay and drain paths under test (replaced by config at runtime).
 #[cfg(test)]
 const MASK_RELAY_IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 const MASK_BUFFER_SIZE: usize = 8192;
@@ -55,6 +51,7 @@ async fn copy_with_idle_timeout<R, W>(
     writer: &mut W,
     byte_cap: usize,
     shutdown_on_eof: bool,
+    idle_timeout: Duration,
 ) -> CopyOutcome
 where
     R: AsyncRead + Unpin,
@@ -78,7 +75,7 @@ where
         }
 
         let read_len = remaining_budget.min(MASK_BUFFER_SIZE);
-        let read_res = timeout(MASK_RELAY_IDLE_TIMEOUT, reader.read(&mut buf[..read_len])).await;
+        let read_res = timeout(idle_timeout, reader.read(&mut buf[..read_len])).await;
         let n = match read_res {
             Ok(Ok(n)) => n,
             Ok(Err(_)) | Err(_) => break,
@@ -86,13 +83,13 @@ where
         if n == 0 {
             ended_by_eof = true;
             if shutdown_on_eof {
-                let _ = timeout(MASK_RELAY_IDLE_TIMEOUT, writer.shutdown()).await;
+                let _ = timeout(idle_timeout, writer.shutdown()).await;
             }
             break;
         }
         total = total.saturating_add(n);
 
-        let write_res = timeout(MASK_RELAY_IDLE_TIMEOUT, writer.write_all(&buf[..n])).await;
+        let write_res = timeout(idle_timeout, writer.write_all(&buf[..n])).await;
         match write_res {
             Ok(Ok(())) => {}
             Ok(Err(_)) | Err(_) => break,
@@ -230,13 +227,20 @@ where
     }
 }
 
-async fn consume_client_data_with_timeout_and_cap<R>(reader: R, byte_cap: usize)
-where
+async fn consume_client_data_with_timeout_and_cap<R>(
+    reader: R,
+    byte_cap: usize,
+    relay_timeout: Duration,
+    idle_timeout: Duration,
+) where
     R: AsyncRead + Unpin,
 {
-    if timeout(MASK_RELAY_TIMEOUT, consume_client_data(reader, byte_cap))
-        .await
-        .is_err()
+    if timeout(
+        relay_timeout,
+        consume_client_data(reader, byte_cap, idle_timeout),
+    )
+    .await
+    .is_err()
     {
         debug!("Timed out while consuming client data on masking fallback path");
     }
@@ -639,10 +643,18 @@ pub async fn handle_bad_client<R, W>(
         beobachten.record(client_type, peer.ip(), ttl);
     }
 
+    let relay_timeout = Duration::from_millis(config.censorship.mask_relay_timeout_ms);
+    let idle_timeout = Duration::from_millis(config.censorship.mask_relay_idle_timeout_ms);
+
     if !config.censorship.mask {
         // Masking disabled, just consume data
-        consume_client_data_with_timeout_and_cap(reader, config.censorship.mask_relay_max_bytes)
-            .await;
+        consume_client_data_with_timeout_and_cap(
+            reader,
+            config.censorship.mask_relay_max_bytes,
+            relay_timeout,
+            idle_timeout,
+        )
+        .await;
         return;
     }
 
@@ -674,7 +686,7 @@ pub async fn handle_bad_client<R, W>(
                     return;
                 }
                 if timeout(
-                    MASK_RELAY_TIMEOUT,
+                    relay_timeout,
                     relay_to_mask(
                         reader,
                         writer,
@@ -688,6 +700,7 @@ pub async fn handle_bad_client<R, W>(
                         config.censorship.mask_shape_above_cap_blur_max_bytes,
                         config.censorship.mask_shape_hardening_aggressive_mode,
                         config.censorship.mask_relay_max_bytes,
+                        idle_timeout,
                     ),
                 )
                 .await
@@ -703,6 +716,8 @@ pub async fn handle_bad_client<R, W>(
                 consume_client_data_with_timeout_and_cap(
                     reader,
                     config.censorship.mask_relay_max_bytes,
+                    relay_timeout,
+                    idle_timeout,
                 )
                 .await;
                 wait_mask_outcome_budget(outcome_started, config).await;
@@ -712,6 +727,8 @@ pub async fn handle_bad_client<R, W>(
                 consume_client_data_with_timeout_and_cap(
                     reader,
                     config.censorship.mask_relay_max_bytes,
+                    relay_timeout,
+                    idle_timeout,
                 )
                 .await;
                 wait_mask_outcome_budget(outcome_started, config).await;
@@ -742,8 +759,13 @@ pub async fn handle_bad_client<R, W>(
             local = %local_addr,
             "Mask target resolves to local listener; refusing self-referential masking fallback"
         );
-        consume_client_data_with_timeout_and_cap(reader, config.censorship.mask_relay_max_bytes)
-            .await;
+        consume_client_data_with_timeout_and_cap(
+            reader,
+            config.censorship.mask_relay_max_bytes,
+            relay_timeout,
+            idle_timeout,
+        )
+        .await;
         wait_mask_outcome_budget(outcome_started, config).await;
         return;
     }
@@ -777,7 +799,7 @@ pub async fn handle_bad_client<R, W>(
                 return;
             }
             if timeout(
-                MASK_RELAY_TIMEOUT,
+                relay_timeout,
                 relay_to_mask(
                     reader,
                     writer,
@@ -791,6 +813,7 @@ pub async fn handle_bad_client<R, W>(
                     config.censorship.mask_shape_above_cap_blur_max_bytes,
                     config.censorship.mask_shape_hardening_aggressive_mode,
                     config.censorship.mask_relay_max_bytes,
+                    idle_timeout,
                 ),
             )
             .await
@@ -806,6 +829,8 @@ pub async fn handle_bad_client<R, W>(
             consume_client_data_with_timeout_and_cap(
                 reader,
                 config.censorship.mask_relay_max_bytes,
+                relay_timeout,
+                idle_timeout,
             )
             .await;
             wait_mask_outcome_budget(outcome_started, config).await;
@@ -815,6 +840,8 @@ pub async fn handle_bad_client<R, W>(
             consume_client_data_with_timeout_and_cap(
                 reader,
                 config.censorship.mask_relay_max_bytes,
+                relay_timeout,
+                idle_timeout,
             )
             .await;
             wait_mask_outcome_budget(outcome_started, config).await;
@@ -836,6 +863,7 @@ async fn relay_to_mask<R, W, MR, MW>(
     shape_above_cap_blur_max_bytes: usize,
     shape_hardening_aggressive_mode: bool,
     mask_relay_max_bytes: usize,
+    idle_timeout: Duration,
 ) where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
@@ -857,11 +885,19 @@ async fn relay_to_mask<R, W, MR, MW>(
                 &mut mask_write,
                 mask_relay_max_bytes,
                 !shape_hardening_enabled,
+                idle_timeout,
             )
             .await
         },
         async {
-            copy_with_idle_timeout(&mut mask_read, &mut writer, mask_relay_max_bytes, true).await
+            copy_with_idle_timeout(
+                &mut mask_read,
+                &mut writer,
+                mask_relay_max_bytes,
+                true,
+                idle_timeout,
+            )
+            .await
         }
     );
 
@@ -889,7 +925,11 @@ async fn relay_to_mask<R, W, MR, MW>(
 }
 
 /// Just consume all data from client without responding.
-async fn consume_client_data<R: AsyncRead + Unpin>(mut reader: R, byte_cap: usize) {
+async fn consume_client_data<R: AsyncRead + Unpin>(
+    mut reader: R,
+    byte_cap: usize,
+    idle_timeout: Duration,
+) {
     if byte_cap == 0 {
         return;
     }
@@ -905,7 +945,7 @@ async fn consume_client_data<R: AsyncRead + Unpin>(mut reader: R, byte_cap: usiz
         }
 
         let read_len = remaining_budget.min(MASK_BUFFER_SIZE);
-        let n = match timeout(MASK_RELAY_IDLE_TIMEOUT, reader.read(&mut buf[..read_len])).await {
+        let n = match timeout(idle_timeout, reader.read(&mut buf[..read_len])).await {
             Ok(Ok(n)) => n,
             Ok(Err(_)) | Err(_) => break,
         };

--- a/src/proxy/tests/masking_additional_hardening_security_tests.rs
+++ b/src/proxy/tests/masking_additional_hardening_security_tests.rs
@@ -47,7 +47,7 @@ async fn consume_client_data_stops_after_byte_cap_without_eof() {
     };
     let cap = 10_000usize;
 
-    consume_client_data(reader, cap).await;
+    consume_client_data(reader, cap, MASK_RELAY_IDLE_TIMEOUT).await;
 
     let total = produced.load(Ordering::Relaxed);
     assert!(

--- a/src/proxy/tests/masking_consume_idle_timeout_security_tests.rs
+++ b/src/proxy/tests/masking_consume_idle_timeout_security_tests.rs
@@ -31,7 +31,7 @@ async fn stalling_client_terminates_at_idle_not_relay_timeout() {
 
     let result = tokio::time::timeout(
         MASK_RELAY_TIMEOUT,
-        consume_client_data(reader, MASK_BUFFER_SIZE * 4),
+        consume_client_data(reader, MASK_BUFFER_SIZE * 4, MASK_RELAY_IDLE_TIMEOUT),
     )
     .await;
 
@@ -57,9 +57,12 @@ async fn fast_reader_drains_to_eof() {
     let data = vec![0xAAu8; 32 * 1024];
     let reader = std::io::Cursor::new(data);
 
-    tokio::time::timeout(MASK_RELAY_TIMEOUT, consume_client_data(reader, usize::MAX))
-        .await
-        .expect("consume_client_data did not complete for fast EOF reader");
+    tokio::time::timeout(
+        MASK_RELAY_TIMEOUT,
+        consume_client_data(reader, usize::MAX, MASK_RELAY_IDLE_TIMEOUT),
+    )
+    .await
+    .expect("consume_client_data did not complete for fast EOF reader");
 }
 
 #[tokio::test]
@@ -81,7 +84,7 @@ async fn io_error_terminates_cleanly() {
 
     tokio::time::timeout(
         MASK_RELAY_TIMEOUT,
-        consume_client_data(ErrReader, usize::MAX),
+        consume_client_data(ErrReader, usize::MAX, MASK_RELAY_IDLE_TIMEOUT),
     )
     .await
     .expect("consume_client_data did not return on I/O error");

--- a/src/proxy/tests/masking_consume_stress_adversarial_tests.rs
+++ b/src/proxy/tests/masking_consume_stress_adversarial_tests.rs
@@ -34,7 +34,11 @@ async fn consume_stall_stress_finishes_within_idle_budget() {
         set.spawn(async {
             tokio::time::timeout(
                 MASK_RELAY_TIMEOUT,
-                consume_client_data(OneByteThenStall { sent: false }, usize::MAX),
+                consume_client_data(
+                    OneByteThenStall { sent: false },
+                    usize::MAX,
+                    MASK_RELAY_IDLE_TIMEOUT,
+                ),
             )
             .await
             .expect("consume_client_data exceeded relay timeout under stall load");
@@ -56,7 +60,7 @@ async fn consume_stall_stress_finishes_within_idle_budget() {
 #[tokio::test]
 async fn consume_zero_cap_returns_immediately() {
     let started = Instant::now();
-    consume_client_data(tokio::io::empty(), 0).await;
+    consume_client_data(tokio::io::empty(), 0, MASK_RELAY_IDLE_TIMEOUT).await;
     assert!(
         started.elapsed() < MASK_RELAY_IDLE_TIMEOUT,
         "zero byte cap must return immediately"

--- a/src/proxy/tests/masking_production_cap_regression_security_tests.rs
+++ b/src/proxy/tests/masking_production_cap_regression_security_tests.rs
@@ -127,7 +127,14 @@ async fn positive_copy_with_production_cap_stops_exactly_at_budget() {
     let mut reader = FinitePatternReader::new(PROD_CAP_BYTES + (256 * 1024), 4096, read_calls);
     let mut writer = CountingWriter::default();
 
-    let outcome = copy_with_idle_timeout(&mut reader, &mut writer, PROD_CAP_BYTES, true).await;
+    let outcome = copy_with_idle_timeout(
+        &mut reader,
+        &mut writer,
+        PROD_CAP_BYTES,
+        true,
+        MASK_RELAY_IDLE_TIMEOUT,
+    )
+    .await;
 
     assert_eq!(
         outcome.total, PROD_CAP_BYTES,
@@ -145,7 +152,13 @@ async fn negative_consume_with_zero_cap_performs_no_reads() {
     let read_calls = Arc::new(AtomicUsize::new(0));
     let reader = FinitePatternReader::new(1024, 64, Arc::clone(&read_calls));
 
-    consume_client_data_with_timeout_and_cap(reader, 0).await;
+    consume_client_data_with_timeout_and_cap(
+        reader,
+        0,
+        MASK_RELAY_TIMEOUT,
+        MASK_RELAY_IDLE_TIMEOUT,
+    )
+    .await;
 
     assert_eq!(
         read_calls.load(Ordering::Relaxed),
@@ -161,7 +174,14 @@ async fn edge_copy_below_cap_reports_eof_without_overread() {
     let mut reader = FinitePatternReader::new(payload, 3072, read_calls);
     let mut writer = CountingWriter::default();
 
-    let outcome = copy_with_idle_timeout(&mut reader, &mut writer, PROD_CAP_BYTES, true).await;
+    let outcome = copy_with_idle_timeout(
+        &mut reader,
+        &mut writer,
+        PROD_CAP_BYTES,
+        true,
+        MASK_RELAY_IDLE_TIMEOUT,
+    )
+    .await;
 
     assert_eq!(outcome.total, payload);
     assert_eq!(writer.written, payload);
@@ -175,7 +195,13 @@ async fn edge_copy_below_cap_reports_eof_without_overread() {
 async fn adversarial_blackhat_never_ready_reader_is_bounded_by_timeout_guards() {
     let started = Instant::now();
 
-    consume_client_data_with_timeout_and_cap(NeverReadyReader, PROD_CAP_BYTES).await;
+    consume_client_data_with_timeout_and_cap(
+        NeverReadyReader,
+        PROD_CAP_BYTES,
+        MASK_RELAY_TIMEOUT,
+        MASK_RELAY_IDLE_TIMEOUT,
+    )
+    .await;
 
     assert!(
         started.elapsed() < Duration::from_millis(350),
@@ -190,7 +216,12 @@ async fn integration_consume_path_honors_production_cap_for_large_payload() {
 
     let bounded = timeout(
         Duration::from_millis(350),
-        consume_client_data_with_timeout_and_cap(reader, PROD_CAP_BYTES),
+        consume_client_data_with_timeout_and_cap(
+            reader,
+            PROD_CAP_BYTES,
+            MASK_RELAY_TIMEOUT,
+            MASK_RELAY_IDLE_TIMEOUT,
+        ),
     )
     .await;
 
@@ -206,7 +237,13 @@ async fn adversarial_consume_path_never_reads_beyond_declared_byte_cap() {
     let total_read = Arc::new(AtomicUsize::new(0));
     let reader = BudgetProbeReader::new(256 * 1024, Arc::clone(&total_read));
 
-    consume_client_data_with_timeout_and_cap(reader, byte_cap).await;
+    consume_client_data_with_timeout_and_cap(
+        reader,
+        byte_cap,
+        MASK_RELAY_TIMEOUT,
+        MASK_RELAY_IDLE_TIMEOUT,
+    )
+    .await;
 
     assert!(
         total_read.load(Ordering::Relaxed) <= byte_cap,
@@ -231,7 +268,9 @@ async fn light_fuzz_cap_and_payload_matrix_preserves_min_budget_invariant() {
         let mut reader = FinitePatternReader::new(payload, chunk, read_calls);
         let mut writer = CountingWriter::default();
 
-        let outcome = copy_with_idle_timeout(&mut reader, &mut writer, cap, true).await;
+        let outcome =
+            copy_with_idle_timeout(&mut reader, &mut writer, cap, true, MASK_RELAY_IDLE_TIMEOUT)
+                .await;
         let expected = payload.min(cap);
 
         assert_eq!(
@@ -261,7 +300,14 @@ async fn stress_parallel_copy_tasks_with_production_cap_complete_without_leaks()
                 read_calls,
             );
             let mut writer = CountingWriter::default();
-            copy_with_idle_timeout(&mut reader, &mut writer, PROD_CAP_BYTES, true).await
+            copy_with_idle_timeout(
+                &mut reader,
+                &mut writer,
+                PROD_CAP_BYTES,
+                true,
+                MASK_RELAY_IDLE_TIMEOUT,
+            )
+            .await
         }));
     }
 

--- a/src/proxy/tests/masking_relay_guardrails_security_tests.rs
+++ b/src/proxy/tests/masking_relay_guardrails_security_tests.rs
@@ -26,6 +26,7 @@ async fn relay_to_mask_enforces_masking_session_byte_cap() {
             0,
             false,
             32 * 1024,
+            MASK_RELAY_IDLE_TIMEOUT,
         )
         .await;
     });
@@ -81,6 +82,7 @@ async fn relay_to_mask_propagates_client_half_close_without_waiting_for_other_di
             0,
             false,
             32 * 1024,
+            MASK_RELAY_IDLE_TIMEOUT,
         )
         .await;
     });

--- a/src/proxy/tests/masking_security_tests.rs
+++ b/src/proxy/tests/masking_security_tests.rs
@@ -1377,6 +1377,7 @@ async fn relay_to_mask_keeps_backend_to_client_flow_when_client_to_backend_stall
             0,
             false,
             5 * 1024 * 1024,
+            MASK_RELAY_IDLE_TIMEOUT,
         )
         .await;
     });
@@ -1508,6 +1509,7 @@ async fn relay_to_mask_timeout_cancels_and_drops_all_io_endpoints() {
             0,
             false,
             5 * 1024 * 1024,
+            MASK_RELAY_IDLE_TIMEOUT,
         ),
     )
     .await;

--- a/src/proxy/tests/masking_self_target_loop_security_tests.rs
+++ b/src/proxy/tests/masking_self_target_loop_security_tests.rs
@@ -228,6 +228,7 @@ async fn relay_path_idle_timeout_eviction_remains_effective() {
         0,
         false,
         5 * 1024 * 1024,
+        MASK_RELAY_IDLE_TIMEOUT,
     )
     .await;
 

--- a/src/proxy/tests/masking_shape_guard_adversarial_tests.rs
+++ b/src/proxy/tests/masking_shape_guard_adversarial_tests.rs
@@ -44,6 +44,7 @@ async fn run_relay_case(
             above_cap_blur_max_bytes,
             false,
             5 * 1024 * 1024,
+            MASK_RELAY_IDLE_TIMEOUT,
         )
         .await;
     });

--- a/src/proxy/tests/masking_shape_hardening_adversarial_tests.rs
+++ b/src/proxy/tests/masking_shape_hardening_adversarial_tests.rs
@@ -89,6 +89,7 @@ async fn relay_to_mask_applies_cap_clamped_padding_for_non_power_of_two_cap() {
             0,
             false,
             5 * 1024 * 1024,
+            MASK_RELAY_IDLE_TIMEOUT,
         )
         .await;
     });


### PR DESCRIPTION
Иногда за telemt находится какой-то долгоживущий сервис (в моем случае это matrix-сервер). Там используется long pooling: клиент открывает соединение на ~30 секунд, если на сервере появились новые данные, то он отправляет их в это соединение. Потом открывается новое 30-секундное соединение.

В telemt были захардкожены `MASK_RELAY_IDLE_TIMEOUT = 5s`, `MASK_RELAY_TIMEOUT = 60s`. В результате соединения обрывались спустя 5 секунд отсутствия данных (и 60 секунд даже если данные были).

Если за telemt находится статическая страница, то это в целом правильное решение: обрубать idle-соединения, чтобы они не тратили ресурсы. Но иногда нужны долгоживущие соединения.

Я сделал эти параметры конфигурируемыми через .toml-файл. Дефолтные значения совпадают с теми, которые были: 5s и 60s.