### PR TITLE
Zabbix template: disable intermediate data storage

### DIFF
--- a/tools/zbx_telemt_template.yaml
+++ b/tools/zbx_telemt_template.yaml
@@ -842,6 +842,7 @@ zabbix_export:
           name: 'Prometheus metrics'
           type: HTTP_AGENT
           key: telemt.prom_metrics
+          history: '0'
           value_type: TEXT
           trends: '0'
           url: '{$TELEMT_URL}'


### PR DESCRIPTION
Предлагаю облегчить хранение данных в Zabbix.
Промежуточные текстовые данные, из которых потом создаются  prometheus items, в zabbix хранить не принято.