### PR TITLE
[FAQ] More user-friendly output when obtaining proxy links

### DIFF
--- a/docs/QUICK_START_GUIDE.en.md
+++ b/docs/QUICK_START_GUIDE.en.md
@@ -150,7 +150,7 @@ systemctl daemon-reload
 
 **7.** To get the link(s), enter:
 ```bash
-curl -s http://127.0.0.1:9091/v1/users | jq
+curl -s http://127.0.0.1:9091/v1/users | jq -r '.data[] | "User: \(.username)\n\(.links.tls[0] // empty)"'
 ```
 
 > Any number of people can use one link.

--- a/docs/QUICK_START_GUIDE.ru.md
+++ b/docs/QUICK_START_GUIDE.ru.md
@@ -150,7 +150,7 @@ systemctl daemon-reload
 
 **7.** Для получения ссылки/ссылок введите 
 ```bash
-curl -s http://127.0.0.1:9091/v1/users | jq
+curl -s http://127.0.0.1:9091/v1/users | jq -r '.data[] | "User: \(.username)\n\(.links.tls[0] // empty)"'
 ```
 > Одной ссылкой может пользоваться сколько угодно человек.
 


### PR DESCRIPTION
Currently output of existing method for obtaining proxy links of users is cluttered, messy and includes many parametes that aren't really needed. This PR changes command for obtaining user's links to not include any strings rather than link for a proxy.