### PR TITLE
FIx XRAY_DOUBLE_HOP.md files.

### DIFF
--- a/docs/Setup_examples/XRAY_DOUBLE_HOP.en.md
+++ b/docs/Setup_examples/XRAY_DOUBLE_HOP.en.md
@@ -37,13 +37,13 @@ xray x25519
 ```
 3. **Short ID (Reality identifier):**
 ```bash
-openssl rand -hex 16
-# Save the output (e.g.: 0123456789abcdef0123456789abcdef) — this is <SHORT_ID>
+openssl rand -hex 8
+# Save the output (e.g.: abc123def456) — this is <SHORT_ID>
 ```
 4. **Random Path (for xhttp):**
 ```bash
-openssl rand -hex 8
-# Save the output (e.g., abc123def456) to replace <YOUR_RANDOM_PATH> in configs
+openssl rand -hex 16
+# Save the output (e.g., 0123456789abcdef0123456789abcdef) to replace <YOUR_RANDOM_PATH> in configs
 ```
 
 ---

--- a/docs/Setup_examples/XRAY_DOUBLE_HOP.ru.md
+++ b/docs/Setup_examples/XRAY_DOUBLE_HOP.ru.md
@@ -37,13 +37,13 @@ xray x25519
 ```
 3. **Short ID (идентификатор Reality):**
 ```bash
-openssl rand -hex 16
-# Сохраните вывод (например: 0123456789abcdef0123456789abcdef) — это <SHORT_ID>
+openssl rand -hex 8
+# Сохраните вывод (например: abc123def456) — это <SHORT_ID>
 ```
 4. **Random Path (путь для xhttp):**
 ```bash
 openssl rand -hex 8
-# Сохраните вывод (например, abc123def456), чтобы заменить <YOUR_RANDOM_PATH> в конфигах
+# Сохраните вывод (например, 0123456789abcdef0123456789abcdef), чтобы заменить <YOUR_RANDOM_PATH> в конфигах
 ```
 
 ---

--- a/docs/Setup_examples/XRAY_DOUBLE_HOP.ru.md
+++ b/docs/Setup_examples/XRAY_DOUBLE_HOP.ru.md
@@ -42,7 +42,7 @@ openssl rand -hex 8
 ```
 4. **Random Path (путь для xhttp):**
 ```bash
-openssl rand -hex 8
+openssl rand -hex 16
 # Сохраните вывод (например, 0123456789abcdef0123456789abcdef), чтобы заменить <YOUR_RANDOM_PATH> в конфигах
 ```
 


### PR DESCRIPTION
### en
Following XRAY_DOUBLE_HOP docs, xray does not setup, and `systemctl status xray` return this
```
Apr 12 14:51:34 nl-vmpico systemd[1]: Started xray.service - Xray Service.
Apr 12 14:51:34 nl-vmpico xray[482292]: Xray 26.3.27 (Xray, Penetrates Everything.) d2758a0 (go1.26.1 linux/amd64)
Apr 12 14:51:34 nl-vmpico xray[482292]: A unified platform for anti-censorship.
Apr 12 14:51:34 nl-vmpico xray[482292]: Failed to start: main: failed to load config files: [/usr/local/etc/xray/config.json] > infra/conf: failed to build inbound config with tag vless-in > infra/conf: Failed to build REALITY config. > infra/conf: too long "shortIds[0]": 0e0239a47ab9bc65ae81cf8075098197
Apr 12 14:51:34 nl-vmpico systemd[1]: xray.service: Main process exited, code=exited, status=23/n/a
Apr 12 14:51:34 nl-vmpico systemd[1]: xray.service: Failed with result 'exit-code'.
```
Fixed by returning <SHORT_ID> to 8 bytes and <YOUR_RANDOM_PATH> to 16 bytes.
