### PR TITLE
Fix path to beobachten file

### DIFF
--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -568,7 +568,7 @@ pub(crate) fn default_beobachten_flush_secs() -> u64 {
 }
 
 pub(crate) fn default_beobachten_file() -> String {
-    "/etc/telemt/beobachten.txt".to_string()
+    "cache/beobachten.txt".to_string()
 }
 
 pub(crate) fn default_tls_new_session_tickets() -> u8 {


### PR DESCRIPTION
/etc/telemt/ must be owned by root:root for security, systemd service sets /var/lib/telemt as WorkingDirectory. Store that file in it by default. It cannot write into /etc/telemt/. systemd services runs telemt from User=telemt.