### PR TITLE
Fix(installer): workaround for systems with secure PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,8 @@ ACTION="install"
 TARGET_VERSION="${VERSION:-latest}"
 LANG_CHOICE="en"
 
+PATH="${PATH}:/usr/sbin:/sbin"
+
 set_language() {
     case "$1" in
         ru)


### PR DESCRIPTION
Предлагаю простейшее исправление проблемы с установкой в Debian.
Для скрипта-инсталлятора вполне разумно модифицировать PATH чтобы сохранить общую логику скрипта простой.


Закрывает баг https://github.com/telemt/telemt/issues/773