### PR TITLE
fix(docker): mount config as directory to allow atomic API writes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,15 @@ services:
       - "443:443"
       - "127.0.0.1:9090:9090"
       - "127.0.0.1:9091:9091"
-    # Allow caching 'proxy-secret' in read-only container
-    working_dir: /etc/telemt
+    # Working dir uses tmpfs for caching 'proxy-secret' at runtime.
+    # Config is mounted as a directory (not a single file) so the API can
+    # atomically update config.toml via write-temp → rename within the same FS.
+    working_dir: /run/telemt
+    command: ["/etc/telemt/config.toml"]
     volumes:
-      - ./config.toml:/etc/telemt/config.toml:ro
+      - ./config:/etc/telemt:rw
     tmpfs:
-      - /etc/telemt:rw,mode=1777,size=4m
+      - /run/telemt:rw,mode=1777,size=4m
     environment:
       - RUST_LOG=info
     healthcheck:
@@ -24,8 +27,6 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
-    # Uncomment this line if you want to use host network for IPv6, but bridge is default and usually better
-    # network_mode: host
     cap_drop:
       - ALL
     cap_add:

--- a/docs/Quick_start/QUICK_START_GUIDE.ru.md
+++ b/docs/Quick_start/QUICK_START_GUIDE.ru.md
@@ -235,7 +235,10 @@ curl -s http://127.0.0.1:9091/v1/users | jq -r '.data[] | "[\(.username)]", (.li
 
 # Telemt через Docker Compose
 
-**1. Отредактируйте `config.toml` в корневом каталоге репозитория (как минимум: порт, пользовательские секреты, tls_domain)**  
+**1. Создайте директорию `config/` и поместите в неё отрдеактированный `config.toml` (указав как минимум: порт, пользовательские секреты, tls_domain):**
+```bash
+mkdir config && mv config.toml config/
+```
 **2. Запустите контейнер:**
 ```bash
 docker compose up -d --build
@@ -249,7 +252,7 @@ docker compose logs -f telemt
 docker compose down
 ```
 > [!NOTE]
-> - В `docker-compose.yml` файл `./config.toml` монтируется в `/app/config.toml` (доступно только для чтения)  
+> - Директория `./config/` монтируется в `/etc/telemt/` (read-write), что позволяет API атомарно обновлять config.toml
 > - По умолчанию публикуются порты 443:443, а контейнер запускается со сброшенными привилегиями (добавлена только `NET_BIND_SERVICE`)  
 > - Если вам действительно нужна сеть хоста (обычно это требуется только для некоторых конфигураций IPv6), раскомментируйте `network_mode: host`
 


### PR DESCRIPTION
Telemt API делает атомарную замену: пишет .tmp-файл → rename(.tmp, config.toml). Rename работает только внутри одной файловой системы. Файловый bind-mount создаёт отдельную точку монтирования прямо в tmpfs — это разные ФС, rename невозможен → EBUSY. При монтировании директории оба файла (.tmp и config.toml) живут на одной ФС хоста.

Нужно: переместить config.toml в поддиректорию config/: