### PR TITLE
Add logging configuration to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,3 +37,8 @@ services:
       nofile:
         soft: 65536
         hard: 262144
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"


### PR DESCRIPTION
There was a disk-full problem.
Some limits applied.