### PR TITLE
Add stable Docker image tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,7 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
         run: |
           set -euo pipefail
 
@@ -398,6 +399,10 @@ jobs:
 
           if [[ "${VERSION}" != *-* ]]; then
             TAGS="${TAGS}"$'\n'"${IMAGE}:latest"
+          fi
+
+          if [ "${PRERELEASE}" = "false" ]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE}:stable"
           fi
 
           {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   telemt:
     image: ghcr.io/telemt/telemt:latest
+    # The stable tag points to the latest non-prerelease Docker image.
+    # image: ghcr.io/telemt/telemt:stable
     build:
       context: .
       target: prod


### PR DESCRIPTION
## Summary

Adds a `stable` Docker image tag for non-prerelease releases while preserving the existing `latest` tag behavior.

Also documents the `stable` image option directly in `docker-compose.yml`.

## Why

This is intended to prevent cases like https://github.com/telemt/telemt/issues/839, where prerelease Docker images may be unsuitable for production usage while users still need an easy way to follow the latest stable container image.

## Validation

- `git diff --check HEAD~1..HEAD`