### PR TITLE
fixed a docker build bug for CI or docker-compose build variations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,16 @@ RUN set -eux; \
     strip --strip-unneeded /telemt || true; \
     rm -f "/tmp/${ASSET}" "/tmp/${ASSET}.sha256" /tmp/telemt
 
+RUN --mount=type=bind,target=/tmp \
+    mkdir -p /app && \
+    if [ -f /tmp/config.toml ]; then \
+        cp /tmp/config.toml /app/config.toml; \
+    elif [ -f /tmp/config/config.toml ]; then \
+        cp /tmp/config/config.toml /app/config.toml; \
+    else \
+        echo "Config file not found" && exit 1; \
+    fi
+
 # ==========================
 # Debug Image
 # ==========================
@@ -99,7 +109,7 @@ RUN set -eux; \
 WORKDIR /app
 
 COPY --from=minimal /telemt /app/telemt
-COPY ./config/config.toml /app/config.toml
+COPY --from=minimal /app/config.toml /app/config.toml
 
 EXPOSE 443 9090 9091
 
@@ -116,7 +126,7 @@ FROM gcr.io/distroless/static-debian12 AS prod
 WORKDIR /app
 
 COPY --from=minimal /telemt /app/telemt
-COPY ./config/config.toml /app/config.toml
+COPY --from=minimal /app/config.toml /app/config.toml
 
 USER nonroot:nonroot
 


### PR DESCRIPTION
Fix #837 #857 
Аналог #858 но ИМХО более корректный, чем директория ради одно файла.

Работает как GH Actions, так и `docker compose build` за счет того, что стэйдж `minimal` сам решает где ему искать конфиг. Убедиться в успешном GH Actions можно так же в репе.

<details>
<summary>Тесты дабы вам не пришлось.</summary>

```bash
mkdir config && mv config.toml config/config.toml && docker compose build --no-cache && echo && DOCKER_BUILDKIT=1 docker build -t telemt:3.4.19-2 . --no-cache                           [+] Building 23.4s (18/18) FINISHED
 => [internal] load local bake definitions                                                                                                                                                               0.0s
 => => reading from stdin 552B                                                                                                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                     0.0s
 => => transferring dockerfile: 3.79kB                                                                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                                                0.8s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89                                                                          0.0s
 => [internal] load metadata for gcr.io/distroless/static-debian12:latest                                                                                                                                0.4s
 => [internal] load metadata for docker.io/library/debian:12-slim                                                                                                                                        0.7s
 => [internal] load .dockerignore                                                                                                                                                                        0.0s
 => => transferring context: 100B                                                                                                                                                                        0.0s
 => CACHED [minimal 1/4] FROM docker.io/library/debian:12-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df                                                                   0.0s
 => [prod 1/4] FROM gcr.io/distroless/static-debian12:latest@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160                                                                     0.0s
 => [internal] load build context                                                                                                                                                                        0.1s
 => => transferring context: 7.72MB                                                                                                                                                                      0.1s
 => CACHED [prod 2/4] WORKDIR /app                                                                                                                                                                       0.0s
 => [minimal 2/4] RUN set -eux;     apt-get update;     apt-get install -y --no-install-recommends         binutils         ca-certificates         curl         tar;     rm -rf /var/lib/apt/lists/*   11.3s
 => [minimal 3/4] RUN set -eux;     case "amd64" in         amd64) ASSET="telemt-x86_64-linux-musl.tar.gz" ;;         arm64) ASSET="telemt-aarch64-linux-musl.tar.gz" ;;         *) echo "Unsupported T  4.5s
 => [minimal 4/4] RUN --mount=type=bind,target=/tmp     mkdir -p /app &&     if [ -f /tmp/config.toml ]; then         cp /tmp/config.toml /app/config.toml;     elif [ -f /tmp/config/config.toml ]; th  1.1s
 => [prod 3/4] COPY --from=minimal /telemt /app/telemt                                                                                                                                                   0.6s
 => [prod 4/4] COPY --from=minimal /app/config.toml /app/config.toml                                                                                                                                     0.4s
 => exporting to image                                                                                                                                                                                   1.7s
 => => exporting layers                                                                                                                                                                                  1.0s
 => => writing image sha256:2791ed234079547a87e6e8c65b903517119571898a7a8938a33fd125679a7aa0                                                                                                             0.1s
 => => naming to ghcr.io/telemt/telemt:latest                                                                                                                                                            0.2s
 => resolving provenance for metadata file                                                                                                                                                               0.0s
[+] Building 1/1
 ✔ ghcr.io/telemt/telemt:latest  Built                                                                                                                                                                   0.0s

[+] Building 29.5s (16/16) FINISHED                                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                     3.3s
 => => transferring dockerfile: 3.79kB                                                                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                                                2.7s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89                                                                          0.0s
 => [internal] load metadata for gcr.io/distroless/static-debian12:latest                                                                                                                                2.5s
 => [internal] load metadata for docker.io/library/debian:12-slim                                                                                                                                        3.1s
 => [internal] load .dockerignore                                                                                                                                                                        0.8s
 => => transferring context: 100B                                                                                                                                                                        0.0s
 => CACHED [minimal 1/4] FROM docker.io/library/debian:12-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df                                                                   0.0s
 => [internal] load build context                                                                                                                                                                        1.1s
 => => transferring context: 23.00kB                                                                                                                                                                     0.0s
 => [prod 1/4] FROM gcr.io/distroless/static-debian12:latest@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160                                                                     0.0s
 => CACHED [prod 2/4] WORKDIR /app                                                                                                                                                                       0.0s
 => [minimal 2/4] RUN set -eux;     apt-get update;     apt-get install -y --no-install-recommends         binutils         ca-certificates         curl         tar;     rm -rf /var/lib/apt/lists/*   12.3s
 => [minimal 3/4] RUN set -eux;     case "amd64" in         amd64) ASSET="telemt-x86_64-linux-musl.tar.gz" ;;         arm64) ASSET="telemt-aarch64-linux-musl.tar.gz" ;;         *) echo "Unsupported T  2.8s
 => [minimal 4/4] RUN --mount=type=bind,target=/tmp     mkdir -p /app &&     if [ -f /tmp/config.toml ]; then         cp /tmp/config.toml /app/config.toml;     elif [ -f /tmp/config/config.toml ]; th  0.2s
 => [prod 3/4] COPY --from=minimal /telemt /app/telemt                                                                                                                                                   0.3s
 => [prod 4/4] COPY --from=minimal /app/config.toml /app/config.toml                                                                                                                                     0.0s
 => exporting to image                                                                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                                                                  0.1s
 => => writing image sha256:a530f1d8dba76d0b7428e2c4f86d792ae42d8653aaade118aec12c60336babbd                                                                                                             0.0s
 => => naming to docker.io/library/telemt:3.4.19-2 
```

</details>