### PR TITLE
fix: do not create runtime disk artifacts before the privilege drop

### DIFF
--- a/src/maestro/runtime_tasks.rs
+++ b/src/maestro/runtime_tasks.rs
@@ -305,7 +305,13 @@ pub(crate) async fn spawn_runtime_tasks(
 
     let beobachten_writer = beobachten.clone();
     let config_rx_beobachten = config_rx.clone();
+    let beobachten_startup_tracker = startup_tracker.clone();
     task_scope.spawn(async move {
+        // The first snapshot must not be written before the runtime is ready:
+        // with --run-as-user the privilege drop happens after listeners are
+        // bound, and a file created before that is owned by root and cannot be
+        // rewritten by the unprivileged process later.
+        beobachten_startup_tracker.wait_ready().await;
         loop {
             let cfg = config_rx_beobachten.borrow().clone();
             let sleep_secs = cfg.general.beobachten_flush_secs.max(1);

--- a/src/maestro/tls_bootstrap.rs
+++ b/src/maestro/tls_bootstrap.rs
@@ -128,12 +128,19 @@ pub(crate) async fn bootstrap_tls_front(
         return Ok(None);
     }
 
-    let cache = Arc::new(TlsFrontCache::new(
-        tls_domains,
-        config.censorship.fake_cert_len,
-        &config.censorship.tls_front_dir,
-    ));
+    let cache = Arc::new(
+        TlsFrontCache::new(
+            tls_domains,
+            config.censorship.fake_cert_len,
+            &config.censorship.tls_front_dir,
+        )
+        // Nothing may be written to `tls_front_dir` before the runtime is
+        // ready: with --run-as-user the privilege drop happens after the TLS
+        // bootstrap, and files created by root would be unwritable later.
+        .with_disk_gate(startup_tracker.ready_watch()),
+    );
     cache.load_from_disk().await;
+    task_scope.spawn(cache.clone().flush_deferred_persist());
 
     let tls_fetch = config.censorship.tls_fetch.clone();
     let fetch_context = TlsFetchContext {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,6 +1,6 @@
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, watch};
 
 pub const COMPONENT_CONFIG_LOAD: &str = "config_load";
 pub const COMPONENT_TRACING_INIT: &str = "tracing_init";
@@ -139,12 +139,16 @@ struct StartupState {
 pub struct StartupTracker {
     started_at_instant: Instant,
     state: RwLock<StartupState>,
+    /// Flips to `true` once the startup pipeline is fully initialized.
+    ready: watch::Sender<bool>,
 }
 
 impl StartupTracker {
     pub fn new(started_at_epoch_secs: u64) -> Self {
+        let (ready, _) = watch::channel(false);
         Self {
             started_at_instant: Instant::now(),
+            ready,
             state: RwLock::new(StartupState {
                 status: StartupStatus::Initializing,
                 degraded: false,
@@ -256,6 +260,25 @@ impl StartupTracker {
         guard.status = StartupStatus::Ready;
         guard.current_stage = "ready".to_string();
         guard.ready_at_epoch_secs = Some(now_epoch_secs());
+        drop(guard);
+        self.ready.send_replace(true);
+    }
+
+    /// Returns a watch that flips to `true` once the runtime is ready.
+    ///
+    /// Readiness is reached only after listeners are bound and, when requested,
+    /// privileges are dropped. Runtime artifacts (caches, snapshots) must not be
+    /// created before that point: files created while still running as root are
+    /// not writable by the unprivileged user afterwards.
+    pub fn ready_watch(&self) -> watch::Receiver<bool> {
+        self.ready.subscribe()
+    }
+
+    /// Waits until the runtime is ready; returns immediately if it already is.
+    pub async fn wait_ready(&self) {
+        let mut ready = self.ready.subscribe();
+        // The sender lives as long as `self`, so this cannot fail while awaited.
+        let _ = ready.wait_for(|ready| *ready).await;
     }
 
     pub async fn snapshot(&self) -> StartupSnapshot {
@@ -378,4 +401,33 @@ fn now_epoch_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn wait_ready_resolves_once_runtime_is_marked_ready() {
+        let tracker = Arc::new(StartupTracker::new(1));
+        let mut ready = tracker.ready_watch();
+        assert!(!*ready.borrow());
+
+        let waiter = {
+            let tracker = tracker.clone();
+            tokio::spawn(async move { tracker.wait_ready().await })
+        };
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        tracker.mark_ready().await;
+        waiter.await.unwrap();
+        assert!(*ready.borrow_and_update());
+
+        // Already ready: returns immediately, also for fresh subscribers.
+        tracker.wait_ready().await;
+        assert!(*tracker.ready_watch().borrow());
+    }
 }

--- a/src/tls_front/cache.rs
+++ b/src/tls_front/cache.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock, watch};
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
 
@@ -41,6 +41,20 @@ pub struct TlsFrontCache {
     full_cert_sent_shards: Vec<RwLock<HashMap<IpAddr, Instant>>>,
     full_cert_sent_last_sweep_epoch_secs: AtomicU64,
     disk_path: PathBuf,
+    /// Disk writes are allowed only while this watch reads `true`.
+    ///
+    /// During startup the gate stays closed until the runtime is ready, i.e.
+    /// until listeners are bound and privileges (if requested) are dropped.
+    /// Files created earlier would belong to root and could never be
+    /// refreshed by the unprivileged process.
+    disk_gate: watch::Receiver<bool>,
+    /// Domains whose on-disk persistence was deferred while the gate was closed.
+    deferred_persist: Mutex<HashSet<String>>,
+}
+
+fn open_disk_gate() -> watch::Receiver<bool> {
+    let (_, gate) = watch::channel(true);
+    gate
 }
 
 /// Read-only health view for one configured TLS front domain.
@@ -124,7 +138,18 @@ impl TlsFrontCache {
                 .collect(),
             full_cert_sent_last_sweep_epoch_secs: AtomicU64::new(0),
             disk_path: disk_path.as_ref().to_path_buf(),
+            disk_gate: open_disk_gate(),
+            deferred_persist: Mutex::new(HashSet::new()),
         }
+    }
+
+    /// Defers on-disk persistence until `gate` reads `true`.
+    ///
+    /// Entries fetched while the gate is closed are kept in memory and written
+    /// out by [`TlsFrontCache::flush_deferred_persist`] once the gate opens.
+    pub fn with_disk_gate(mut self, gate: watch::Receiver<bool>) -> Self {
+        self.disk_gate = gate;
+        self
     }
 
     pub async fn get(&self, sni: &str) -> Arc<CachedTlsData> {
@@ -331,10 +356,10 @@ impl TlsFrontCache {
     }
 
     pub async fn load_from_disk(&self) {
+        // Read-only: the cache directory is created lazily by the first
+        // persist, which runs only after the runtime is ready (privileges
+        // dropped), so it ends up owned by the user the proxy runs as.
         let path = self.disk_path.clone();
-        if tokio::fs::create_dir_all(&path).await.is_err() {
-            return;
-        }
         let mut loaded = 0usize;
         if let Ok(mut dir) = tokio::fs::read_dir(&path).await {
             while let Ok(Some(entry)) = dir.next_entry().await {
@@ -392,6 +417,21 @@ impl TlsFrontCache {
     }
 
     async fn persist(&self, domain: &str, data: &CachedTlsData) {
+        if !*self.disk_gate.borrow() {
+            self.deferred_persist
+                .lock()
+                .await
+                .insert(domain.to_string());
+            // Re-check after queueing: if the gate opened meanwhile, the
+            // flusher may already have drained the set, so write directly.
+            if !*self.disk_gate.borrow() {
+                return;
+            }
+        }
+        self.write_to_disk(domain, data).await;
+    }
+
+    async fn write_to_disk(&self, domain: &str, data: &CachedTlsData) {
         if tokio::fs::create_dir_all(&self.disk_path).await.is_err() {
             return;
         }
@@ -400,6 +440,27 @@ impl TlsFrontCache {
         if let Ok(json) = serde_json::to_vec_pretty(data) {
             // best-effort write
             let _ = tokio::fs::write(path, json).await;
+        }
+    }
+
+    /// Waits for the disk gate to open, then persists every entry whose
+    /// write was deferred while it was closed. Returns immediately (as a
+    /// no-op) when the gate is already open and nothing was deferred.
+    pub async fn flush_deferred_persist(self: Arc<Self>) {
+        let mut gate = self.disk_gate.clone();
+        if gate.wait_for(|open| *open).await.is_err() {
+            return;
+        }
+        let deferred: Vec<String> = std::mem::take(&mut *self.deferred_persist.lock().await)
+            .into_iter()
+            .collect();
+        for domain in deferred {
+            let entry = self.memory.read().await.get(&domain).cloned();
+            if let Some(entry) = entry
+                && !Arc::ptr_eq(&entry, &self.default)
+            {
+                self.write_to_disk(&domain, &entry).await;
+            }
         }
     }
 
@@ -556,6 +617,49 @@ mod tests {
     fn cert_info_domain_match_rejects_multi_label_wildcard_san() {
         let cached = cached_with_cert_info("deep.api.b.com", None, vec!["*.b.com"]);
         assert!(!cert_info_matches_domain(&cached));
+    }
+
+    #[tokio::test]
+    async fn load_from_disk_does_not_create_cache_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let disk_path = dir.path().join("tlsfront");
+        let cache = TlsFrontCache::new(&["a.com".to_string()], 1024, &disk_path);
+
+        cache.load_from_disk().await;
+
+        assert!(!disk_path.exists());
+    }
+
+    #[tokio::test]
+    async fn persist_is_deferred_until_disk_gate_opens() {
+        let dir = tempfile::tempdir().unwrap();
+        let disk_path = dir.path().join("tlsfront");
+        let (gate_tx, gate_rx) = watch::channel(false);
+        let cache = Arc::new(
+            TlsFrontCache::new(&["a.com".to_string()], 1024, &disk_path).with_disk_gate(gate_rx),
+        );
+        let entry = cached_with_cert_info("a.com", None, vec!["a.com"]);
+        cache.set("a.com", entry.clone()).await;
+
+        cache.persist("a.com", &entry).await;
+        assert!(
+            !disk_path.exists(),
+            "nothing may touch the disk while the gate is closed"
+        );
+
+        let flusher = tokio::spawn(cache.clone().flush_deferred_persist());
+        tokio::task::yield_now().await;
+        assert!(!flusher.is_finished());
+
+        gate_tx.send_replace(true);
+        flusher.await.unwrap();
+        assert!(disk_path.join("a.com.json").is_file());
+
+        // With the gate open, writes are immediate again.
+        let entry = cached_with_cert_info("b.com", None, vec!["b.com"]);
+        cache.set("b.com", entry.clone()).await;
+        cache.persist("b.com", &entry).await;
+        assert!(disk_path.join("b.com.json").is_file());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

With `--run-as-user`/`--run-as-group`, `drop_privileges()` runs after `bind_listeners()`
(so privileged ports can be bound first) — but `prepare_runtime()` has already started
tasks that write to the runtime directory by then. Everything written in that window is
created as root and can never be rewritten by the unprivileged process afterwards.

Two writers hit this window deterministically:

1. **beobachten snapshot** — the flush loop in `maestro/runtime_tasks.rs` is
   write-then-sleep, so the first snapshot is always written before the drop. Every
   subsequent flush (`tokio::fs::write` = `O_TRUNC`, needs write permission on the file
   itself) then fails, once per `beobachten_flush_secs`:

   ```
   WARN telemt::maestro::runtime_tasks: Failed to flush beobachten snapshot error=Permission denied (os error 13) path=beobachten.txt
   ```

2. **TLS front cache** — `bootstrap_tls_front()` runs before the drop:
   `TlsFrontCache::load_from_disk()` creates `tls_front_dir` as root, and whenever the
   initial fetch completes before the drop (always with `RequireReady`, usually with
   `BestEffort`) `<domain>.json` is written as root too. Since `persist()` is
   best-effort (`let _ = tokio::fs::write(...)`), later refreshes fail *silently* — the
   on-disk cache simply never gets updated again, and after a restart the profile has to
   be re-fetched.

Observed on FreeBSD with v3.5.5, freshly created working directory
(`--working-dir /var/db/telemt --run-as-user telemt --run-as-group telemt`):

```
-rw-r--r--   1 root   telemt   6 Aug 30 17:21 beobachten.txt
drwxr-xr-x   2 telemt telemt   4 Aug 30 17:21 cache
-rw-r--r--   1 telemt telemt 128 Aug 30 17:21 proxy-secret
drwxr-xr-x   2 root   telemt   3 Aug 30 17:21 tlsfront
```

(`cache/` and `proxy-secret` happen to be written after the drop with the default
`me2dc_fallback = true`, hence owned correctly. Group `telemt` on the root-owned entries
is just BSD group inheritance from the directory; on Linux they come out `root:root`.)

Notably, `drop_privileges()` already handles exactly this class of problem for the PID
file (`fchown` before `setuid`) — the other startup artifacts were missed.

## Fix

Three commits, smallest first:

- **startup**: `StartupTracker` gains `ready_watch()` / `wait_ready()` backed by a
  `tokio::sync::watch` channel flipped in `mark_ready()`. Readiness is reached only
  after `bind_listeners()` and `drop_after_bind()`, so "ready" reliably implies
  "privileges dropped". No behavior change by itself.

- **beobachten**: the flush task awaits `wait_ready()` before its first write. On hot
  reload the tracker is already ready, so re-spawned tasks are unaffected.

- **tls_front**: `load_from_disk()` becomes read-only (no `create_dir_all`), and
  `TlsFrontCache` gets an optional disk gate (`with_disk_gate(watch::Receiver<bool>)`).
  While the gate is closed, `persist()` only records the domain;
  `flush_deferred_persist()` (spawned in the generation task scope by
  `bootstrap_tls_front()`, wired to `ready_watch()`) waits for the gate and writes the
  recorded entries from memory. With the gate open — the default for existing
  constructors, tests, metrics, and on hot reload — writes are immediate, as before.

## Testing

- `cargo test`: full suite passes (2051 passed / 0 failed), including three new unit
  tests: readiness watch semantics, deferred-persist flush, and `load_from_disk` not
  creating the directory. `cargo fmt` / `clippy` clean for the touched files.
- End-to-end with `--run-as-user`/`--run-as-group` and a fresh working dir, TLS
  emulation enabled: **before** — `beobachten.txt`, `tlsfront/` and
  `tlsfront/<domain>.json` owned by root plus the flush warnings above; **after** — all
  three created by the service user once the runtime is ready, no warnings, and a
  restart logs `Loaded TLS cache entries from disk count=1`.

## Out of scope

The middle-proxy write-through caches (`proxy_secret_path`,
`proxy_config_v{4,6}_cache_path` in `transport/middle_proxy/{secret,config_updater}.rs`)
can also be written before the drop when `me2dc_fallback = false` (ME pool init is
awaited pre-bind in that configuration). Gating those means threading a gate through the
transport-layer API, so it is deliberately left out of this series; happy to do it as a
follow-up if there's interest in the approach.
