### PR TITLE
fix(web): allow configured memory envelopes above 4 GiB

### DIFF
--- a/docs/Config_params/CONFIG_PARAMS.de.md
+++ b/docs/Config_params/CONFIG_PARAMS.de.md
@@ -2638,7 +2638,7 @@ Diese prozessweiten Obergrenzen begrenzen alle WEB-Register, Warteschlangen, Req
 | `max_static_bytes` | `usize` | `67108864` | Bytes statischer Snapshots über alle vhosts. |
 | `debug_records_capacity` | `usize` | `65536` | Maximale Zahl gespeicherter WEB-Debugdatensätze. |
 | `debug_bytes_global` | `usize` | `67108864` | Globale Byte-Obergrenze für gespeicherte und in Verarbeitung befindliche WEB-Debugdaten; mindestens 4096. |
-| `memory_envelope_bytes` | `usize` | `1342177280` | Deklarierter Rahmen für HTTP-Heads, Bodys, gemeinsame Queues/WebSocket-I/O, Lane-Zustand, Carrier-Learning, statische Snapshots und begrenzte Debug-/Statuspuffer; maximal 4 GiB. |
+| `memory_envelope_bytes` | `usize` | `1342177280` | Deklarierter Rahmen für HTTP-Heads, Bodys, gemeinsame Queues/WebSocket-I/O, Lane-Zustand, Carrier-Learning, statische Snapshots und begrenzte Debug-/Statuspuffer. |
 | `new_bootstraps_per_minute` | `u32` | `1200` | Nachhaltige prozessweite Ausgaberate für Bootstraps. |
 | `new_bootstraps_burst` | `u32` | `256` | Prozessweiter Burst für die Bootstrap-Ausgabe. |
 | `new_sessions_per_minute` | `u32` | `600` | Nachhaltige prozessweite Erstellungsrate für Sitzungen. |

--- a/docs/Config_params/CONFIG_PARAMS.en.md
+++ b/docs/Config_params/CONFIG_PARAMS.en.md
@@ -2638,7 +2638,7 @@ These process-wide ceilings make every WEB registry, queue, request body, static
 | `max_static_bytes` | `usize` | `67108864` | Static snapshot bytes across all vhosts. |
 | `debug_records_capacity` | `usize` | `65536` | Maximum retained WEB debug record count. |
 | `debug_bytes_global` | `usize` | `67108864` | Retained plus in-flight WEB debug byte ceiling; minimum 4096. |
-| `memory_envelope_bytes` | `usize` | `1342177280` | Declared envelope for HTTP heads, bodies, shared queues/WebSocket I/O, lane state, carrier learning, static snapshots, and bounded debug/status buffers; maximum 4 GiB. |
+| `memory_envelope_bytes` | `usize` | `1342177280` | Declared envelope for HTTP heads, bodies, shared queues/WebSocket I/O, lane state, carrier learning, static snapshots, and bounded debug/status buffers; reservations must fit the configured envelope, with checked arithmetic bounded by the target platform's `usize`. |
 | `new_bootstraps_per_minute` | `u32` | `1200` | Sustained process-wide bootstrap issuance rate. |
 | `new_bootstraps_burst` | `u32` | `256` | Process-wide bootstrap issuance burst. |
 | `new_sessions_per_minute` | `u32` | `600` | Sustained process-wide session creation rate. |

--- a/docs/Config_params/CONFIG_PARAMS.ru.md
+++ b/docs/Config_params/CONFIG_PARAMS.ru.md
@@ -2564,7 +2564,7 @@ WEB-режим переносит MTProxy-трафик Telegram Desktop внут
 | `max_static_bytes` | `usize` | `67108864` | Размер static snapshots всех vhosts. |
 | `debug_records_capacity` | `usize` | `65536` | Максимальное число сохранённых WEB debug records. |
 | `debug_bytes_global` | `usize` | `67108864` | Глобальная байтовая граница сохранённых и находящихся в обработке WEB debug данных; минимум 4096. |
-| `memory_envelope_bytes` | `usize` | `1342177280` | Заявленный envelope для HTTP heads, bodies, общих queues/WebSocket I/O, состояния lanes, carrier learning, static snapshots и bounded debug/status buffers; максимум 4 GiB. |
+| `memory_envelope_bytes` | `usize` | `1342177280` | Заявленный envelope для HTTP heads, bodies, общих queues/WebSocket I/O, состояния lanes, carrier learning, static snapshots и bounded debug/status buffers. |
 | `new_bootstraps_per_minute` | `u32` | `1200` | Устойчивая process-wide скорость выдачи bootstrap. |
 | `new_bootstraps_burst` | `u32` | `256` | Process-wide burst выдачи bootstrap. |
 | `new_sessions_per_minute` | `u32` | `600` | Устойчивая process-wide скорость создания сессий. |

--- a/src/config/load/validate_web.rs
+++ b/src/config/load/validate_web.rs
@@ -23,7 +23,6 @@ const MAX_WEB_BODY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_WEB_FRAME_BYTES: usize = 1024 * 1024;
 const MAX_WEB_FRAMES_PER_BODY: usize = 4096;
 const MAX_WEB_TOMBSTONES_PER_SESSION: usize = 4096;
-const MAX_WEB_MEMORY_ENVELOPE_BYTES: usize = 4 * 1024 * 1024 * 1024;
 
 /// Validates WEB policy and resource bounds before building runtime state.
 pub(super) fn validate(config: &mut ProxyConfig) -> Result<()> {

--- a/src/config/load/validate_web/memory.rs
+++ b/src/config/load/validate_web/memory.rs
@@ -78,12 +78,8 @@ pub(super) fn validate(limits: &WebLimitsConfig) -> Result<()> {
         .and_then(|value| value.checked_add(lane_state_reservation))
         .and_then(|value| value.checked_add(http_header_reservation))
         .ok_or_else(|| ProxyError::Config("web.limits byte ceilings overflow usize".to_string()))?;
-    if reserved > limits.memory_envelope_bytes
-        || limits.memory_envelope_bytes > MAX_WEB_MEMORY_ENVELOPE_BYTES
-    {
-        return config_error(
-            "web.limits memory reservations must fit memory_envelope_bytes within 4 GiB",
-        );
+    if reserved > limits.memory_envelope_bytes {
+        return config_error("web.limits memory reservations must fit memory_envelope_bytes");
     }
     Ok(())
 }
@@ -91,6 +87,45 @@ pub(super) fn validate(limits: &WebLimitsConfig) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn operator_budget_above_four_gib_is_accepted() {
+        let limits = WebLimitsConfig {
+            pending_bytes_global: 5 * 1024 * 1024 * 1024,
+            memory_envelope_bytes: 8 * 1024 * 1024 * 1024,
+            ..WebLimitsConfig::default()
+        };
+        assert!(validate(&limits).is_ok());
+    }
+
+    #[test]
+    fn configured_envelope_still_rejects_overcommit() {
+        let defaults = WebLimitsConfig::default();
+        let limits = WebLimitsConfig {
+            pending_bytes_global: defaults.memory_envelope_bytes,
+            ..defaults
+        };
+        assert!(matches!(
+            validate(&limits),
+            Err(ProxyError::Config(message))
+                if message == "web.limits memory reservations must fit memory_envelope_bytes"
+        ));
+    }
+
+    #[test]
+    fn configured_envelope_still_rejects_overflow() {
+        let limits = WebLimitsConfig {
+            pending_bytes_global: usize::MAX,
+            memory_envelope_bytes: usize::MAX,
+            ..WebLimitsConfig::default()
+        };
+        assert!(matches!(
+            validate(&limits),
+            Err(ProxyError::Config(message))
+                if message == "web.limits byte ceilings overflow usize"
+        ));
+    }
 
     #[test]
     fn default_envelope_includes_bounded_lane_and_learning_metadata() {


### PR DESCRIPTION
WEB configurations are currently rejected whenever `memory_envelope_bytes`
exceeds 4 GiB, even when the configured reservations fit that envelope and their
arithmetic is representable on the target. This prevents operators from scaling
otherwise valid WEB configurations through the existing resource settings.

Remove the fixed upper ceiling and continue validating reservations against the
configured envelope. Checked multiplication/addition, body-size representation
bounds and the other WEB admission limits remain intact. Default values and the
serialized configuration format do not change; no new runtime allocation or
data-path work is introduced.

Add a 64-bit test accepting an 8 GiB envelope with a 5 GiB pending-byte budget,
plus architecture-neutral tests rejecting overcommit and arithmetic overflow.
Update the English, Russian and German parameter documentation.

Related: #916 fixes the 32-bit representation of the existing ceiling. This PR
removes that ceiling instead, while continuing to use checked `usize` arithmetic.
It does not claim complete 32-bit build/runtime validation.

Validation on the signed PR commit: Build, formatting and Clippy passed;
`cargo nextest run` passed 2,051 tests with 72 skipped
([test run](https://github.com/Misha20062006/telemt/actions/runs/33882148952/job/101053208093)).
