### PR TITLE
fix(install): probe only TCP when validating the target port

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -447,9 +447,9 @@ check_port_availability() {
     port_info=""
 
     if command -v ss >/dev/null 2>&1; then
-        port_info=$($SUDO ss -tulnp 2>/dev/null | grep -E ":${SERVER_PORT}([[:space:]]|$)" || true)
+        port_info=$($SUDO ss -tlnp 2>/dev/null | grep -E ":${SERVER_PORT}([[:space:]]|$)" || true)
     elif command -v netstat >/dev/null 2>&1; then
-        port_info=$($SUDO netstat -tulnp 2>/dev/null | grep -E ":${SERVER_PORT}([[:space:]]|$)" || true)
+        port_info=$($SUDO netstat -tlnp 2>/dev/null | grep -E ":${SERVER_PORT}([[:space:]]|$)" || true)
     elif command -v lsof >/dev/null 2>&1; then
         port_info=$($SUDO lsof -i :${SERVER_PORT} 2>/dev/null | grep LISTEN || true)
     else


### PR DESCRIPTION
### Problem
check_port_availability() probes both TCP and UDP (ss -tulnp, netstat -tulnp), while telemt only ever binds a TCP listener. Any unrelated UDP socket sharing the port number aborts the install with `Port is already in use by another process`

Real-world case: a WireGuard/AmneziaWG endpoint on 443/udp on the same host. 443/tcp is free and telemt would start and run fine, but the installer refuses to proceed, forcing the user onto another port and a manual config edit.

### Fix
Drop -u from both branches so only TCP listening sockets are considered. The lsof branch is left untouched — its `| grep LISTEN` already filters UDP out.

#### Testing (Ubuntu, ss and netstat branches, port 54443):
- only 54443/udp bound → before: install dies; after: proceeds
- 54443/tcp bound by a foreign process → dies in both (unchanged)
- 54443/tcp bound by a process named telemt → Ignoring as it will be restarted in both (unchanged)
